### PR TITLE
Phase 6 P0-A: spawn_oz.py cloud-agent backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ __pycache__/
 .venv/
 .pytest_cache/
 *.pyc
+
+# MemPalace per-project files (issue #185)
+mempalace.yaml
+entities.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
 [project.scripts]
 maw-spawn-docker = "scripts.spawn_docker:main"
 maw-spawn-k8s = "scripts.spawn_k8s:main"
+maw-spawn-oz = "scripts.spawn_oz:main"
 maw-wait-phase = "scripts.wait_for_phase:main"
 maw-aggregate = "scripts.aggregate_results:main"
 maw-eval = "scripts.run_evals:main"

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -1,0 +1,61 @@
+"""Shared helpers for multi-agent-workflows spawn backends.
+
+Kept module-private (leading underscore) so it's clear this is internal
+plumbing, not part of the public script surface. Each spawn_* script
+imports from here to avoid duplicating fault-tolerance logic.
+"""
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+from typing import Protocol
+
+
+class _HasStatus(Protocol):
+    """Duck-typed result with a `status` attribute (ok, partial, failed, etc)."""
+
+    status: str
+
+
+def calculate_backoff(retry: int, base_delay: float = 2.0, max_delay: float = 60.0) -> float:
+    """Exponential backoff with 10% jitter. retry is 0-indexed."""
+    delay = min(base_delay * (2 ** retry), max_delay)
+    jitter = delay * 0.1 * random.random()
+    return delay + jitter
+
+
+def check_circuit_breaker(
+    results: list[_HasStatus],
+    threshold: float,
+    min_samples: int = 3,
+) -> bool:
+    """Return True if the failure rate over `results` exceeds `threshold`.
+
+    `min_samples` guards against early false positives when only 1-2 results
+    have come back.
+    """
+    if len(results) < min_samples:
+        return False
+    failed = sum(1 for r in results if r.status == "failed")
+    return (failed / len(results)) > threshold
+
+
+def validate_tasks_file(path: Path) -> list[str]:
+    """Load tasks from a file; blank lines and `# ...` comments are skipped.
+
+    Exits with status 1 on missing file or empty task list — this is a CLI
+    helper, not library code.
+    """
+    if not path.exists():
+        print(f"Error: Tasks file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    tasks = [
+        line.strip()
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+    if not tasks:
+        print(f"Error: No tasks found in {path}", file=sys.stderr)
+        sys.exit(1)
+    return tasks

--- a/scripts/spawn_oz.py
+++ b/scripts/spawn_oz.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""
+Spawn parallel agents on Warp's Oz cloud platform.
+
+Fans out tasks via `oz agent run-cloud`, optionally waits for them to reach
+a terminal state, and emits structured per-run results (including artifact
+URLs when agents produce PRs).
+
+Usage:
+    python3 spawn_oz.py --tasks "t1" "t2" --environment ENV_ID --wait --json
+    python3 spawn_oz.py --tasks-file tasks.txt --environment ENV_ID --parallel 8
+
+Design notes:
+    - `--environment` is **required**. Oz cloud agents have no implicit env.
+    - No Docker-style flags (--image, --memory, --cpus, --network). Those are
+      managed via `oz environment` and are deliberately out of scope here.
+    - Credentials default to `env` backend: cloud agents inherit Oz-provisioned
+      secrets as env vars at runtime. On the admin Mac, spawn_oz itself just
+      needs `WARP_API_KEY` to call the `oz` CLI.
+    - `--wait` blocks per-run via `oz run get` polling. Without it, spawn_oz
+      returns immediately after launching all runs (fire-and-forget, useful
+      for scheduled workflows).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# Shared helpers
+try:
+    from scripts._common import calculate_backoff, check_circuit_breaker, validate_tasks_file  # type: ignore
+except ImportError:
+    try:
+        from ._common import calculate_backoff, check_circuit_breaker, validate_tasks_file  # type: ignore
+    except ImportError:
+        # Fallback: direct script execution without package context
+        sys.path.insert(0, str(Path(__file__).parent))
+        from _common import calculate_backoff, check_circuit_breaker, validate_tasks_file  # type: ignore
+
+try:
+    from scripts.credential_helper import resolve_secret  # type: ignore
+except ImportError:
+    try:
+        from .credential_helper import resolve_secret  # type: ignore
+    except ImportError:
+        resolve_secret = None  # type: ignore
+
+
+OZ_TERMINAL_STATES = {"succeeded", "failed", "cancelled", "completed", "errored"}
+OZ_RUN_GET_POLL_SEC = 5.0
+OZ_RUN_GET_MAX_WAIT_SEC = 3600
+
+
+@dataclass
+class OzAgentResult:
+    """Result of launching (and optionally waiting on) an Oz cloud agent."""
+
+    task_id: str
+    task: str
+    run_id: str
+    status: str  # "running", "succeeded", "failed", "cancelled"
+    error: Optional[str] = None
+    retries: int = 0
+    start_time: Optional[float] = None
+    end_time: Optional[float] = None
+    output: Optional[str] = None
+    pr_url: Optional[str] = None
+    branch: Optional[str] = None
+    raw_run_get: Optional[dict] = field(default=None, repr=False)
+
+    @property
+    def duration_seconds(self) -> Optional[float]:
+        if self.start_time and self.end_time:
+            return self.end_time - self.start_time
+        return None
+
+    def to_envelope(self) -> dict:
+        """Emit in the common result envelope (references/result-schema.md)."""
+        # Map internal Oz states to envelope-canonical status.
+        status = "ok" if self.status in {"succeeded", "completed"} else (
+            "failed" if self.status in {"failed", "cancelled", "errored"} else "partial"
+        )
+        env: dict = {
+            "schema_version": "1",
+            "status": status,
+            "task_id": self.task_id,
+            "data": {
+                "run_id": self.run_id,
+                "output": self.output,
+                "pr_url": self.pr_url,
+                "branch": self.branch,
+            },
+        }
+        if self.error:
+            env["error"] = self.error
+        if self.duration_seconds is not None:
+            env["metrics"] = {"duration_seconds": self.duration_seconds}
+        return env
+
+
+def generate_task_id(task: str, index: int, phase: Optional[str] = None) -> str:
+    """Generate a run-naming slug. Oz auto-assigns run_id server-side, this is
+    purely a client-side handle used in the output envelope."""
+    safe_name = task.lower().replace(" ", "-").replace("_", "-")
+    safe_name = "".join(c for c in safe_name if c.isalnum() or c == "-")
+    if phase:
+        return f"ozagent-{phase}-{index}-{safe_name[:25]}"
+    return f"ozagent-{index}-{safe_name[:30]}"
+
+
+def check_oz_available() -> tuple[bool, str]:
+    """Preflight: oz CLI installed and WARP_API_KEY reachable."""
+    if not any(
+        os.access(os.path.join(p, "oz"), os.X_OK)
+        for p in os.environ.get("PATH", "").split(os.pathsep)
+        if p
+    ):
+        return False, "`oz` CLI not found in PATH. Install Warp CLI: https://docs.warp.dev/reference/cli"
+    # `oz` returns 0 for help even without auth; real check happens at spawn time.
+    try:
+        result = subprocess.run(
+            ["oz", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return False, f"oz --version failed: {result.stderr.strip()}"
+        return True, result.stdout.strip() or "oz CLI available"
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return False, f"Failed to invoke oz: {e}"
+
+
+def spawn_oz_agent(
+    task: str,
+    task_id: str,
+    environment: str,
+    extra_env: Optional[dict] = None,
+) -> OzAgentResult:
+    """Spawn a single Oz cloud agent run. Returns immediately after launch."""
+    cmd = [
+        "oz",
+        "agent",
+        "run-cloud",
+        "--prompt",
+        task,
+        "--environment",
+        environment,
+        "--output-format",
+        "json",
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        return OzAgentResult(
+            task_id=task_id,
+            task=task,
+            run_id="",
+            status="failed",
+            error=(e.stderr or str(e)).strip(),
+        )
+    except FileNotFoundError:
+        return OzAgentResult(
+            task_id=task_id,
+            task=task,
+            run_id="",
+            status="failed",
+            error="`oz` CLI not found in PATH",
+        )
+
+    run_id = _parse_run_id(proc.stdout)
+    if not run_id:
+        return OzAgentResult(
+            task_id=task_id,
+            task=task,
+            run_id="",
+            status="failed",
+            error=f"Could not parse run_id from oz output: {proc.stdout[:200]!r}",
+        )
+    return OzAgentResult(
+        task_id=task_id,
+        task=task,
+        run_id=run_id,
+        status="running",
+        start_time=time.time(),
+    )
+
+
+def _parse_run_id(stdout: str) -> Optional[str]:
+    """Extract run_id from either JSON (preferred) or pretty/text output.
+
+    Accepts:
+      - {"run_id": "..."} or {"id": "...", ...}
+      - "Spawned agent with run ID: <uuid>" (text format)
+    """
+    if not stdout:
+        return None
+    # JSON first
+    try:
+        data = json.loads(stdout)
+        if isinstance(data, dict):
+            for k in ("run_id", "id", "runId", "run"):
+                if k in data and isinstance(data[k], str):
+                    return data[k]
+    except (json.JSONDecodeError, ValueError):
+        pass
+    # Text fallback: look for a UUID-shaped token
+    m = re.search(
+        r"\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b",
+        stdout,
+        re.IGNORECASE,
+    )
+    return m.group(1) if m else None
+
+
+def poll_run(run_id: str) -> dict:
+    """Fetch current state of a run via `oz run get`. Returns parsed JSON."""
+    proc = subprocess.run(
+        ["oz", "run", "get", run_id, "--output-format", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return {"status": "unknown", "error": proc.stderr.strip()}
+    try:
+        return json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError) as e:
+        return {"status": "unknown", "error": f"malformed JSON: {e}"}
+
+
+def wait_for_run(
+    result: OzAgentResult,
+    poll_sec: float = OZ_RUN_GET_POLL_SEC,
+    max_wait_sec: int = OZ_RUN_GET_MAX_WAIT_SEC,
+) -> OzAgentResult:
+    """Block until the run reaches a terminal state or we time out."""
+    deadline = time.time() + max_wait_sec
+    while time.time() < deadline:
+        payload = poll_run(result.run_id)
+        state = str(payload.get("status") or payload.get("state") or "").lower()
+        if state in OZ_TERMINAL_STATES:
+            result.end_time = time.time()
+            result.status = state
+            result.raw_run_get = payload
+            result.output = payload.get("output") or payload.get("agent_output")
+            # Look for PR artifact mentions in output
+            if result.output:
+                pr_match = re.search(
+                    r"https://github\.com/[\w.\-]+/[\w.\-]+/pull/\d+",
+                    result.output,
+                )
+                if pr_match:
+                    result.pr_url = pr_match.group(0)
+                branch_match = re.search(r"branch[:\s]+['\"]?([\w./\-]+)", result.output)
+                if branch_match:
+                    result.branch = branch_match.group(1)
+            return result
+        time.sleep(poll_sec)
+    result.end_time = time.time()
+    result.status = "failed"
+    result.error = f"Timed out after {max_wait_sec}s waiting for run {result.run_id}"
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Spawn parallel cloud agents on Warp's Oz platform",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --tasks "Summarize auth" "Review DB layer" --environment UA17BXYZ --wait --json
+  %(prog)s --tasks-file tasks.txt --environment UA17BXYZ --parallel 8
+""",
+    )
+
+    # Task input
+    task_group = parser.add_argument_group("Task Input (one required)")
+    task_group.add_argument("--tasks", nargs="+", metavar="PROMPT", help="Task prompts")
+    task_group.add_argument("--tasks-file", type=Path, metavar="FILE", help="File with tasks (one per line)")
+
+    # Oz config
+    oz_group = parser.add_argument_group("Oz Configuration")
+    oz_group.add_argument(
+        "--environment",
+        required=True,
+        metavar="ENV_ID",
+        help="Oz environment ID to run agents in (required). Use `oz environment list` to find yours.",
+    )
+
+    # Execution
+    exec_group = parser.add_argument_group("Execution Control")
+    exec_group.add_argument("--parallel", type=int, default=4, metavar="N", help="Max parallel spawns (default: %(default)s)")
+    exec_group.add_argument("--timeout", type=int, default=OZ_RUN_GET_MAX_WAIT_SEC, metavar="SEC", help="Per-run wait timeout (default: %(default)s)")
+    exec_group.add_argument("--poll-interval", type=float, default=OZ_RUN_GET_POLL_SEC, metavar="SEC", help="Polling interval when --wait (default: %(default)s)")
+    exec_group.add_argument("--phase", metavar="ID", help="Phase identifier for multi-phase workflows")
+
+    # Fault tolerance
+    fault_group = parser.add_argument_group("Fault Tolerance")
+    fault_group.add_argument("--circuit-breaker", type=float, default=0.5, metavar="RATIO", help="Stop spawning if failure rate exceeds threshold (default: %(default)s)")
+    fault_group.add_argument("--retry-failed", action="store_true", help="Retry failed spawns with exponential backoff")
+    fault_group.add_argument("--max-retries", type=int, default=3, metavar="N", help="Max retries per task (default: %(default)s)")
+    fault_group.add_argument("--skip-preflight", action="store_true", help="Skip `oz --version` preflight")
+    fault_group.add_argument(
+        "--credential-backend",
+        choices=["env", "keychain", "1password", "vault", "aws", "oz"],
+        default="env",
+        help="Backend for resolving WARP_API_KEY (default: env — cloud agents inherit secrets as env vars)",
+    )
+
+    # Output
+    out_group = parser.add_argument_group("Output")
+    out_group.add_argument("--wait", action="store_true", help="Wait for all runs to reach terminal state")
+    out_group.add_argument("--json", action="store_true", help="Emit results as JSON envelope per task")
+    out_group.add_argument("--output-dir", type=Path, default=Path("./outputs"), metavar="DIR", help="Directory to write per-run result.json (default: %(default)s)")
+
+    args = parser.parse_args()
+
+    # WARP_API_KEY sanity check (oz CLI needs it)
+    api_key: Optional[str] = None
+    if resolve_secret is not None:
+        try:
+            api_key = resolve_secret("WARP_API_KEY", backend=args.credential_backend)
+        except Exception as e:
+            print(f"Warning: credential backend failed ({e}); falling back to env", file=sys.stderr)
+    if not api_key:
+        api_key = os.environ.get("WARP_API_KEY")
+    if not api_key:
+        print(
+            "Error: WARP_API_KEY not found. Set via one of:\n"
+            "  - export WARP_API_KEY=...\n"
+            "  - python3 scripts/credential_helper.py set WARP_API_KEY\n"
+            "  - Inside an Oz cloud agent, it is injected automatically",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Preflight
+    if not args.skip_preflight:
+        ok, msg = check_oz_available()
+        if not ok:
+            print(f"✗ Preflight: {msg}", file=sys.stderr)
+            print("Run with --skip-preflight to bypass.", file=sys.stderr)
+            return 1
+        print(f"✓ {msg}", file=sys.stderr)
+
+    # Load tasks
+    if args.tasks:
+        tasks = args.tasks
+    elif args.tasks_file:
+        tasks = validate_tasks_file(args.tasks_file)
+    else:
+        parser.error("Must provide --tasks or --tasks-file")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    results: list[OzAgentResult] = []
+    print(f"Spawning {len(tasks)} cloud agents in environment {args.environment}...", file=sys.stderr)
+
+    with ThreadPoolExecutor(max_workers=args.parallel) as pool:
+        futures = {}
+        for i, task in enumerate(tasks):
+            if check_circuit_breaker(results, args.circuit_breaker):
+                print(
+                    f"Circuit breaker tripped at {args.circuit_breaker * 100:.0f}% failure rate; halting spawn.",
+                    file=sys.stderr,
+                )
+                break
+            task_id = generate_task_id(task, i, args.phase)
+            fut = pool.submit(spawn_oz_agent, task=task, task_id=task_id, environment=args.environment)
+            futures[fut] = (task, task_id)
+
+        for fut in as_completed(futures):
+            task, task_id = futures[fut]
+            r = fut.result()
+            results.append(r)
+            if r.status == "running":
+                print(f"✓ Spawned: {task_id} (run={r.run_id}) — {task[:60]}", file=sys.stderr)
+            else:
+                print(f"✗ Spawn failed: {task_id} — {r.error}", file=sys.stderr)
+                if args.retry_failed and r.retries < args.max_retries:
+                    # Simple retry (sequential; keeps parallelism code simple)
+                    for attempt in range(args.max_retries):
+                        backoff = calculate_backoff(attempt)
+                        time.sleep(backoff)
+                        retry = spawn_oz_agent(task=task, task_id=task_id, environment=args.environment)
+                        retry.retries = attempt + 1
+                        if retry.status == "running":
+                            results[-1] = retry
+                            print(f"✓ Retry {attempt + 1} succeeded: {task_id}", file=sys.stderr)
+                            break
+
+    # Wait if requested
+    if args.wait:
+        print("\nWaiting for cloud agents to reach terminal state...", file=sys.stderr)
+        for r in results:
+            if r.status == "running":
+                wait_for_run(r, poll_sec=args.poll_interval, max_wait_sec=args.timeout)
+                sym = "✓" if r.status in {"succeeded", "completed"} else "✗"
+                dur = f"{r.duration_seconds:.1f}s" if r.duration_seconds else "?"
+                print(f"{sym} {r.task_id} [{r.status}] ({dur})", file=sys.stderr)
+
+    # Persist envelopes
+    for r in results:
+        env = r.to_envelope()
+        task_out = args.output_dir / r.task_id
+        task_out.mkdir(parents=True, exist_ok=True)
+        (task_out / "result.json").write_text(json.dumps(env, indent=2))
+
+    # Stdout output
+    if args.json:
+        payload = {
+            "tasks_total": len(tasks),
+            "tasks_spawned": sum(1 for r in results if r.run_id),
+            "tasks_succeeded": sum(1 for r in results if r.status in {"succeeded", "completed"}),
+            "tasks_failed": sum(1 for r in results if r.status in {"failed", "cancelled", "errored"}),
+            "results": [r.to_envelope() for r in results],
+        }
+        print(json.dumps(payload, indent=2))
+
+    # Exit code: non-zero if any failures
+    return 0 if all(r.status in {"succeeded", "completed", "running"} for r in results) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,62 @@
+"""Tests for scripts/_common.py."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from scripts import _common
+
+
+@dataclass
+class _R:
+    status: str
+
+
+class TestCalculateBackoff:
+    def test_grows_exponentially(self):
+        a = _common.calculate_backoff(0, base_delay=1.0, max_delay=100.0)
+        b = _common.calculate_backoff(3, base_delay=1.0, max_delay=100.0)
+        # 1s baseline grows to ~8s at retry=3 (plus <10% jitter)
+        assert 0.9 <= a <= 1.2
+        assert 7.9 <= b <= 9.0
+
+    def test_clamps_to_max(self):
+        d = _common.calculate_backoff(20, base_delay=1.0, max_delay=5.0)
+        assert d <= 5.5  # max + jitter
+
+
+class TestCheckCircuitBreaker:
+    def test_under_min_samples_returns_false(self):
+        assert not _common.check_circuit_breaker([_R("failed"), _R("failed")], 0.3)
+
+    def test_at_min_samples_trips(self):
+        rs = [_R("failed"), _R("failed"), _R("failed")]
+        assert _common.check_circuit_breaker(rs, 0.3)
+
+    def test_below_threshold_does_not_trip(self):
+        rs = [_R("failed"), _R("ok"), _R("ok")]
+        assert not _common.check_circuit_breaker(rs, 0.5)
+
+    def test_custom_min_samples(self):
+        assert not _common.check_circuit_breaker([_R("failed")] * 4, 0.5, min_samples=5)
+        assert _common.check_circuit_breaker([_R("failed")] * 5, 0.5, min_samples=5)
+
+
+class TestValidateTasksFile:
+    def test_loads_non_empty_lines(self, tmp_path):
+        f = tmp_path / "tasks.txt"
+        f.write_text("task one\n\n# a comment\ntask two\n")
+        assert _common.validate_tasks_file(f) == ["task one", "task two"]
+
+    def test_missing_file_exits(self, tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            _common.validate_tasks_file(tmp_path / "missing.txt")
+        assert exc.value.code == 1
+
+    def test_empty_file_exits(self, tmp_path):
+        f = tmp_path / "tasks.txt"
+        f.write_text("\n# only comments\n\n")
+        with pytest.raises(SystemExit) as exc:
+            _common.validate_tasks_file(f)
+        assert exc.value.code == 1

--- a/tests/test_spawn_oz.py
+++ b/tests/test_spawn_oz.py
@@ -1,0 +1,214 @@
+"""Tests for scripts/spawn_oz.py."""
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest import mock
+
+import pytest
+
+from scripts import spawn_oz
+
+
+class TestParseRunId:
+    def test_parses_run_id_from_json(self):
+        out = '{"run_id": "5972cca4-a410-42af-930a-e56bc23e07ac", "status": "pending"}'
+        assert spawn_oz._parse_run_id(out) == "5972cca4-a410-42af-930a-e56bc23e07ac"
+
+    def test_parses_id_fallback_field(self):
+        out = '{"id": "abc12345-a410-42af-930a-e56bc23e07ac"}'
+        assert spawn_oz._parse_run_id(out) == "abc12345-a410-42af-930a-e56bc23e07ac"
+
+    def test_parses_uuid_from_text_output(self):
+        out = "Spawned agent with run ID: 5972CCA4-A410-42AF-930A-E56BC23E07AC\nDone."
+        assert spawn_oz._parse_run_id(out) == "5972CCA4-A410-42AF-930A-E56BC23E07AC"
+
+    def test_returns_none_on_empty(self):
+        assert spawn_oz._parse_run_id("") is None
+
+    def test_returns_none_on_unparseable(self):
+        assert spawn_oz._parse_run_id("some random output with no uuid") is None
+
+
+class TestGenerateTaskId:
+    def test_includes_phase(self):
+        tid = spawn_oz.generate_task_id("Analyze the auth module", 3, phase="phase1")
+        assert tid.startswith("ozagent-phase1-3-")
+        assert "analyze-the-auth" in tid
+
+    def test_without_phase(self):
+        tid = spawn_oz.generate_task_id("x y z", 0)
+        assert tid.startswith("ozagent-0-")
+
+    def test_sanitizes_nonalnum(self):
+        tid = spawn_oz.generate_task_id("foo@bar!baz", 0)
+        assert "@" not in tid and "!" not in tid
+
+
+class TestSpawnOzAgent:
+    def test_success_returns_running_with_run_id(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            assert cmd[:3] == ["oz", "agent", "run-cloud"]
+            assert "--environment" in cmd
+            assert "UA17BXYZ" in cmd
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout='{"run_id": "5972cca4-a410-42af-930a-e56bc23e07ac"}',
+                stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        r = spawn_oz.spawn_oz_agent(task="test", task_id="t1", environment="UA17BXYZ")
+        assert r.status == "running"
+        assert r.run_id == "5972cca4-a410-42af-930a-e56bc23e07ac"
+        assert r.start_time is not None
+        assert r.error is None
+
+    def test_oz_cli_error_returns_failed(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd, stderr="Not authenticated")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        r = spawn_oz.spawn_oz_agent(task="test", task_id="t1", environment="X")
+        assert r.status == "failed"
+        assert "Not authenticated" in r.error
+        assert r.run_id == ""
+
+    def test_missing_oz_cli_returns_failed(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            raise FileNotFoundError("oz")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        r = spawn_oz.spawn_oz_agent(task="test", task_id="t1", environment="X")
+        assert r.status == "failed"
+        assert "oz" in r.error.lower()
+
+    def test_unparseable_output_returns_failed(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout="Success but no run id here", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        r = spawn_oz.spawn_oz_agent(task="test", task_id="t1", environment="X")
+        assert r.status == "failed"
+        assert "Could not parse run_id" in r.error
+
+
+class TestPollRun:
+    def test_returns_parsed_json_on_success(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout='{"status": "succeeded", "output": "all good"}',
+                stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        data = spawn_oz.poll_run("abc")
+        assert data["status"] == "succeeded"
+
+    def test_returns_unknown_on_nonzero(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="run not found")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        data = spawn_oz.poll_run("abc")
+        assert data["status"] == "unknown"
+        assert "run not found" in data["error"]
+
+    def test_malformed_json_handled(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout="not json", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        data = spawn_oz.poll_run("abc")
+        assert data["status"] == "unknown"
+        assert "malformed JSON" in data["error"]
+
+
+class TestWaitForRun:
+    def test_terminal_state_captured(self, monkeypatch):
+        r = spawn_oz.OzAgentResult(
+            task_id="t1", task="x", run_id="abc", status="running", start_time=1.0
+        )
+
+        def fake_poll(run_id):
+            return {
+                "status": "succeeded",
+                "output": "Created PR: https://github.com/foo/bar/pull/42 on branch feature/x",
+            }
+
+        monkeypatch.setattr(spawn_oz, "poll_run", fake_poll)
+        monkeypatch.setattr(spawn_oz.time, "sleep", lambda _s: None)
+        result = spawn_oz.wait_for_run(r, poll_sec=0.0, max_wait_sec=5)
+        assert result.status == "succeeded"
+        assert result.pr_url == "https://github.com/foo/bar/pull/42"
+        assert result.branch == "feature/x"
+        assert result.end_time is not None
+
+    def test_non_terminal_times_out(self, monkeypatch):
+        r = spawn_oz.OzAgentResult(
+            task_id="t1", task="x", run_id="abc", status="running", start_time=1.0
+        )
+
+        def fake_poll(run_id):
+            return {"status": "running"}
+
+        monkeypatch.setattr(spawn_oz, "poll_run", fake_poll)
+        monkeypatch.setattr(spawn_oz.time, "sleep", lambda _s: None)
+        # Tight deadline
+        result = spawn_oz.wait_for_run(r, poll_sec=0.0, max_wait_sec=0)
+        assert result.status == "failed"
+        assert "Timed out" in result.error
+
+
+class TestToEnvelope:
+    def test_succeeded_maps_to_ok(self):
+        r = spawn_oz.OzAgentResult(
+            task_id="t1", task="x", run_id="abc",
+            status="succeeded", start_time=1.0, end_time=3.5,
+            output="done", pr_url="https://github.com/a/b/pull/1",
+        )
+        env = r.to_envelope()
+        assert env["schema_version"] == "1"
+        assert env["status"] == "ok"
+        assert env["task_id"] == "t1"
+        assert env["data"]["run_id"] == "abc"
+        assert env["data"]["pr_url"] == "https://github.com/a/b/pull/1"
+        assert env["metrics"]["duration_seconds"] == pytest.approx(2.5)
+
+    def test_failed_maps_to_failed(self):
+        r = spawn_oz.OzAgentResult(
+            task_id="t1", task="x", run_id="", status="failed", error="boom",
+        )
+        env = r.to_envelope()
+        assert env["status"] == "failed"
+        assert env["error"] == "boom"
+
+    def test_running_maps_to_partial(self):
+        r = spawn_oz.OzAgentResult(task_id="t1", task="x", run_id="abc", status="running")
+        assert r.to_envelope()["status"] == "partial"
+
+
+class TestCheckOzAvailable:
+    def test_missing_cli(self, monkeypatch):
+        monkeypatch.setenv("PATH", "/nonexistent")
+        ok, msg = spawn_oz.check_oz_available()
+        assert not ok
+        assert "not found" in msg
+
+    def test_version_check_ok(self, monkeypatch, tmp_path):
+        # Fake an oz binary on PATH (executable)
+        fake_oz = tmp_path / "oz"
+        fake_oz.write_text("#!/bin/sh\necho oz-1.0\n")
+        fake_oz.chmod(0o755)
+        monkeypatch.setenv("PATH", str(tmp_path))
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout="oz 1.0.0\n", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ok, msg = spawn_oz.check_oz_available()
+        assert ok
+        assert "1.0.0" in msg


### PR DESCRIPTION
Adds a new spawn backend targeting Warp's Oz cloud platform via `oz agent run-cloud`.

## Highlights
- `scripts/_common.py` extracts shared helpers (backoff, circuit breaker, tasks-file loader) for reuse across spawn backends.
- `scripts/spawn_oz.py` fans out cloud agents, optionally waits for terminal state, captures PR/branch artifacts from agent output, emits result-schema envelopes.
- `--environment` is **required** per the plan's Q1 decision (no implicit default).
- `--wait` opt-in; default is fire-and-forget per the plan's Q2 decision.
- `--credential-backend` defaults to `env` (cloud agents inherit secrets as env vars).

## Tests
+31 tests across `test_common.py` and `test_spawn_oz.py`. **200/200 passing** (up from 169).

## Surface
- New entry point: `maw-spawn-oz`.
- No changes to existing scripts.

Conversation: https://app.warp.dev/conversation/eafbfe6f-cef2-4e02-84be-720ef9f77c1f

Co-Authored-By: Oz <oz-agent@warp.dev>