### PR TITLE
Phase 6 P0-B: opt-in result-schema enforcement

### DIFF
--- a/references/result-schema.json
+++ b/references/result-schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/13DJTEQ/multi-agent-workflows/schemas/result-envelope/v1",
+  "title": "Multi-Agent Workflows Result Envelope v1",
+  "description": "Minimal common envelope for sub-agent results. See references/result-schema.md for rationale and migration plan.",
+  "type": "object",
+  "required": ["schema_version", "status"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1",
+      "description": "Envelope version. Bump on breaking changes."
+    },
+    "status": {
+      "enum": ["ok", "partial", "failed"],
+      "description": "Terminal status from the agent's perspective."
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Client-assigned task identifier, matches spawn_* task_id."
+    },
+    "error": {
+      "type": "string",
+      "description": "Error description when status is not 'ok'."
+    },
+    "data": {
+      "description": "Workflow-specific result payload. Free-form."
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Performance/cost metrics. Well-known fields: duration_seconds, tokens_used, cost_usd, model.",
+      "properties": {
+        "duration_seconds": {"type": "number", "minimum": 0},
+        "tokens_used": {"type": "integer", "minimum": 0},
+        "cost_usd": {"type": "number", "minimum": 0},
+        "model": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Source metadata: agent, model, commit, timestamps.",
+      "properties": {
+        "agent": {"type": "string"},
+        "model": {"type": "string"},
+        "commit": {"type": "string"},
+        "started_at": {"type": "string"},
+        "finished_at": {"type": "string"}
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -256,7 +256,15 @@ Examples:
     # Metadata
     parser.add_argument("--include-provenance", action="store_true", help="Include source info")
     parser.add_argument("--include-stats", action="store_true", help="Include aggregation statistics")
-    
+
+    # Schema enforcement (opt-in; see references/result-schema.md)
+    parser.add_argument(
+        "--validate-schema",
+        action="store_true",
+        help="Validate each input against references/result-schema.json (v1 envelope). "
+             "Drops status=='failed' entries from merge/concat; malformed envelopes abort.",
+    )
+
     args = parser.parse_args()
     
     # Collect input files
@@ -294,19 +302,54 @@ Examples:
     else:
         loaded = [load_file(f) for f in input_files]
     
+    status_counts: Counter = Counter()
+    schema_errors: list[tuple[str, list[str]]] = []
+    validator_schema = None
+    if args.validate_schema:
+        try:
+            from scripts.schema_validator import validate_envelope, _load_schema  # type: ignore
+        except ImportError:
+            try:
+                from .schema_validator import validate_envelope, _load_schema  # type: ignore
+            except ImportError:
+                sys.path.insert(0, str(Path(__file__).parent))
+                from schema_validator import validate_envelope, _load_schema  # type: ignore
+        validator_schema = _load_schema()
+
     for f, data in loaded:
-        if data is not None:
-            results.append(data)
-            if args.include_provenance:
-                agent_id = f.parent.name if f.parent != args.input_dir else f.stem
-                provenance[agent_id] = {
-                    "file": str(f),
-                    "timestamp": datetime.fromtimestamp(f.stat().st_mtime).isoformat(),
-                }
-        else:
+        if data is None:
             failed_files.append(str(f))
             if not args.skip_invalid:
                 print(f"Warning: Failed to load {f}", file=sys.stderr)
+            continue
+
+        if args.validate_schema and isinstance(data, dict):
+            vr = validate_envelope(data, schema=validator_schema)
+            if not vr.ok:
+                schema_errors.append((str(f), vr.errors))
+                failed_files.append(str(f))
+                print(f"Schema: {f} ✗ {'; '.join(vr.errors)}", file=sys.stderr)
+                continue
+            status = data.get("status")
+            status_counts[str(status)] += 1
+            # Drop status=='failed' entries from aggregation per migration plan
+            if status == "failed":
+                continue
+
+        results.append(data)
+        if args.include_provenance:
+            agent_id = f.parent.name if f.parent != args.input_dir else f.stem
+            provenance[agent_id] = {
+                "file": str(f),
+                "timestamp": datetime.fromtimestamp(f.stat().st_mtime).isoformat(),
+            }
+
+    if args.validate_schema and schema_errors:
+        print(
+            f"Error: {len(schema_errors)} envelope(s) failed schema validation. Aborting.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     
     # Check success ratio
     total = len(input_files)
@@ -363,6 +406,8 @@ Examples:
             }
             if failed_files:
                 output["stats"]["failed_files"] = failed_files
+            if args.validate_schema and status_counts:
+                output["stats"]["status_breakdown"] = dict(status_counts)
     else:
         output = aggregated
     

--- a/scripts/schema_validator.py
+++ b/scripts/schema_validator.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Validate agent result envelopes against references/result-schema.json.
+
+Provides:
+- Library API: `validate_envelope(obj) -> ValidationResult`
+- CLI: `python3 scripts/schema_validator.py outputs/*/result.json`
+
+Works with or without the `jsonschema` package installed:
+- If `jsonschema` is available, full draft-2020-12 validation runs.
+- Otherwise, a built-in minimal validator checks the envelope's required
+  fields and enum values (sufficient for the v1 envelope; falls back gracefully).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+_HERE = Path(__file__).resolve().parent
+_SCHEMA_PATH = _HERE.parent / "references" / "result-schema.json"
+
+VALID_STATUS = {"ok", "partial", "failed"}
+SCHEMA_VERSION_CONST = "1"
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating one envelope. `ok=True` means it passed."""
+
+    ok: bool
+    path: Optional[Path] = None
+    errors: list[str] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+def _load_schema() -> dict:
+    if not _SCHEMA_PATH.exists():
+        raise FileNotFoundError(
+            f"Schema not found at {_SCHEMA_PATH}. "
+            "This file ships with the skill; reinstall if missing."
+        )
+    return json.loads(_SCHEMA_PATH.read_text())
+
+
+def _builtin_validate(obj: Any) -> list[str]:
+    """Minimal validator used when the `jsonschema` package is unavailable.
+
+    Checks the invariants v1 callers actually rely on:
+    - obj is a dict
+    - has required fields: schema_version, status
+    - schema_version == "1"
+    - status in {ok, partial, failed}
+    """
+    errors: list[str] = []
+    if not isinstance(obj, dict):
+        return [f"envelope must be a JSON object, got {type(obj).__name__}"]
+    if "schema_version" not in obj:
+        errors.append("missing required field: schema_version")
+    elif obj["schema_version"] != SCHEMA_VERSION_CONST:
+        errors.append(
+            f"schema_version must be '{SCHEMA_VERSION_CONST}', got {obj['schema_version']!r}"
+        )
+    if "status" not in obj:
+        errors.append("missing required field: status")
+    elif obj["status"] not in VALID_STATUS:
+        errors.append(f"status must be one of {sorted(VALID_STATUS)}, got {obj['status']!r}")
+    # metrics / provenance must be dicts if present
+    for field_name in ("metrics", "provenance"):
+        if field_name in obj and not isinstance(obj[field_name], dict):
+            errors.append(f"{field_name} must be an object if present")
+    return errors
+
+
+def _jsonschema_validate(obj: Any, schema: dict) -> list[str]:
+    import jsonschema  # type: ignore
+
+    validator = jsonschema.Draft202012Validator(schema)
+    return [e.message for e in sorted(validator.iter_errors(obj), key=lambda e: e.path)]
+
+
+def validate_envelope(obj: Any, schema: Optional[dict] = None) -> ValidationResult:
+    """Validate a single envelope object. Returns ValidationResult(ok, errors).
+
+    Uses `jsonschema` if importable; otherwise falls back to built-in checks.
+    """
+    if schema is None:
+        schema = _load_schema()
+    try:
+        errors = _jsonschema_validate(obj, schema)
+    except ImportError:
+        errors = _builtin_validate(obj)
+    return ValidationResult(ok=not errors, errors=errors)
+
+
+def validate_file(path: Path, schema: Optional[dict] = None) -> ValidationResult:
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        return ValidationResult(ok=False, path=path, errors=[f"failed to load {path}: {e}"])
+    result = validate_envelope(data, schema=schema)
+    result.path = path
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate agent result envelopes against the v1 schema.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s outputs/**/result.json
+  %(prog)s path/to/one.json --quiet
+""",
+    )
+    parser.add_argument("files", nargs="+", type=Path, help="Envelope JSON files to validate")
+    parser.add_argument("--quiet", action="store_true", help="Suppress per-file OK lines; only print failures")
+    args = parser.parse_args()
+
+    schema = _load_schema()
+    failed = 0
+    for p in args.files:
+        r = validate_file(p, schema=schema)
+        if r.ok:
+            if not args.quiet:
+                print(f"\u2713 {p}")
+        else:
+            failed += 1
+            print(f"\u2717 {p}")
+            for e in r.errors:
+                print(f"  - {e}")
+    if failed:
+        print(f"\n{failed} of {len(args.files)} files failed validation.", file=sys.stderr)
+        return 1
+    print(f"\n{len(args.files)} of {len(args.files)} files valid.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -1,0 +1,166 @@
+"""Tests for scripts/schema_validator.py + --validate-schema integration."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import schema_validator as sv
+
+
+VALID = {
+    "schema_version": "1",
+    "status": "ok",
+    "task_id": "t1",
+    "data": {"result": "fine"},
+    "metrics": {"duration_seconds": 1.5},
+}
+
+
+class TestBuiltinValidator:
+    def test_valid_envelope(self):
+        assert sv._builtin_validate(VALID) == []
+
+    def test_missing_schema_version(self):
+        errs = sv._builtin_validate({"status": "ok"})
+        assert any("schema_version" in e for e in errs)
+
+    def test_wrong_schema_version(self):
+        errs = sv._builtin_validate({"schema_version": "2", "status": "ok"})
+        assert any("schema_version must be '1'" in e for e in errs)
+
+    def test_missing_status(self):
+        errs = sv._builtin_validate({"schema_version": "1"})
+        assert any("status" in e for e in errs)
+
+    def test_invalid_status(self):
+        errs = sv._builtin_validate({"schema_version": "1", "status": "ready"})
+        assert any("status must be one of" in e for e in errs)
+
+    def test_not_a_dict(self):
+        errs = sv._builtin_validate(["list", "not", "dict"])
+        assert any("JSON object" in e for e in errs)
+
+    def test_bad_metrics_type(self):
+        errs = sv._builtin_validate(
+            {"schema_version": "1", "status": "ok", "metrics": "not-a-dict"}
+        )
+        assert any("metrics must be an object" in e for e in errs)
+
+    def test_extra_fields_allowed(self):
+        """additionalProperties: true — extra fields should not fail."""
+        assert sv._builtin_validate({**VALID, "custom_field": 42, "nested": {"k": "v"}}) == []
+
+
+class TestValidateEnvelope:
+    def test_ok_result(self):
+        r = sv.validate_envelope(VALID)
+        assert r.ok
+        assert r.errors == []
+        assert bool(r) is True
+
+    def test_bad_result(self):
+        r = sv.validate_envelope({"status": "ok"})  # missing schema_version
+        assert not r.ok
+        assert r.errors
+        assert bool(r) is False
+
+
+class TestValidateFile:
+    def test_valid_file(self, tmp_path):
+        p = tmp_path / "r.json"
+        p.write_text(json.dumps(VALID))
+        r = sv.validate_file(p)
+        assert r.ok
+        assert r.path == p
+
+    def test_invalid_json_file(self, tmp_path):
+        p = tmp_path / "r.json"
+        p.write_text("{not json}")
+        r = sv.validate_file(p)
+        assert not r.ok
+        assert any("failed to load" in e for e in r.errors)
+
+    def test_missing_file(self, tmp_path):
+        r = sv.validate_file(tmp_path / "nope.json")
+        assert not r.ok
+
+
+class TestCliRunner:
+    def test_cli_passes_on_valid(self, tmp_path):
+        p = tmp_path / "r.json"
+        p.write_text(json.dumps(VALID))
+        proc = subprocess.run(
+            [sys.executable, "-m", "scripts.schema_validator", str(p), "--quiet"],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+        )
+        assert proc.returncode == 0
+
+    def test_cli_fails_on_invalid(self, tmp_path):
+        p = tmp_path / "r.json"
+        p.write_text(json.dumps({"status": "bogus"}))  # invalid
+        proc = subprocess.run(
+            [sys.executable, "-m", "scripts.schema_validator", str(p)],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+        )
+        assert proc.returncode == 1
+
+
+class TestAggregateValidateSchemaIntegration:
+    def _mk(self, dirpath: Path, name: str, envelope: dict):
+        d = dirpath / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "result.json").write_text(json.dumps(envelope))
+
+    def test_drops_failed_entries_from_merge(self, tmp_path):
+        out = tmp_path / "outputs"
+        self._mk(out, "a", {"schema_version": "1", "status": "ok", "data": {"x": 1}})
+        self._mk(out, "b", {"schema_version": "1", "status": "failed", "error": "boom"})
+        self._mk(out, "c", {"schema_version": "1", "status": "ok", "data": {"y": 2}})
+        report = tmp_path / "report.json"
+
+        proc = subprocess.run(
+            [
+                sys.executable, "-m", "scripts.aggregate_results",
+                "--input-dir", str(out),
+                "--output", str(report),
+                "--strategy", "merge",
+                "--validate-schema",
+                "--include-stats",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+        )
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(report.read_text())
+        # Failed entry dropped -> merged data only has x and y
+        assert payload["stats"]["status_breakdown"] == {"ok": 2, "failed": 1}
+
+    def test_aborts_on_malformed_envelope(self, tmp_path):
+        out = tmp_path / "outputs"
+        self._mk(out, "a", {"schema_version": "1", "status": "ok", "data": {"x": 1}})
+        self._mk(out, "bad", {"status": "ok"})  # missing schema_version
+        report = tmp_path / "report.json"
+
+        proc = subprocess.run(
+            [
+                sys.executable, "-m", "scripts.aggregate_results",
+                "--input-dir", str(out),
+                "--output", str(report),
+                "--strategy", "merge",
+                "--validate-schema",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+        )
+        assert proc.returncode != 0
+        assert "failed schema validation" in proc.stderr


### PR DESCRIPTION
Advances the `references/result-schema.md` migration plan from step 1 to step 3: schema validation is now flag-gated opt-in.

## Highlights
- `references/result-schema.json` — JSON Schema draft-2020-12 for the v1 envelope.
- `scripts/schema_validator.py` — library + CLI with graceful fallback (works with or without `jsonschema` installed).
- `scripts/aggregate_results.py --validate-schema` — drops `status='failed'` entries from merge/concat, aborts on malformed envelopes, surfaces per-status breakdown in `--include-stats`.

## Compatibility
`--validate-schema` is opt-in per Q3 decision; flag-absent behavior unchanged.

## Tests
+17 tests. **217/217 passing** (up from 200).

Conversation: https://app.warp.dev/conversation/eafbfe6f-cef2-4e02-84be-720ef9f77c1f

Co-Authored-By: Oz <oz-agent@warp.dev>