### PR TITLE
Phase 6 P1-C: Oz cost/metrics surface

### DIFF
--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -221,6 +221,56 @@ STRATEGIES: dict[str, Callable] = {
 }
 
 
+def _rollup_metrics(results: list[Any]) -> dict:
+    """Sum metrics.* fields across result envelopes (P1-C).
+
+    Only operates on entries that look like the v1 envelope
+    (dict with a ``metrics`` sub-dict). Returns totals plus a per-model
+    breakdown when ``metrics.model`` is present.
+    """
+    total_tokens = 0
+    total_cost = 0.0
+    total_duration = 0.0
+    per_model: dict[str, dict] = {}
+    saw_any = False
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        m = r.get("metrics")
+        if not isinstance(m, dict):
+            continue
+        saw_any = True
+        tokens = m.get("tokens_used")
+        cost = m.get("cost_usd")
+        dur = m.get("duration_seconds")
+        model = m.get("model")
+        if isinstance(tokens, (int, float)):
+            total_tokens += int(tokens)
+        if isinstance(cost, (int, float)):
+            total_cost += float(cost)
+        if isinstance(dur, (int, float)):
+            total_duration += float(dur)
+        if isinstance(model, str):
+            bucket = per_model.setdefault(model, {"count": 0, "tokens_used": 0, "cost_usd": 0.0})
+            bucket["count"] += 1
+            if isinstance(tokens, (int, float)):
+                bucket["tokens_used"] += int(tokens)
+            if isinstance(cost, (int, float)):
+                bucket["cost_usd"] += float(cost)
+    if not saw_any:
+        return {}
+    result: dict = {}
+    if total_tokens:
+        result["total_tokens"] = total_tokens
+    if total_cost:
+        result["total_cost_usd"] = round(total_cost, 6)
+    if total_duration:
+        result["total_duration_seconds"] = round(total_duration, 3)
+    if per_model:
+        result["per_model"] = per_model
+    return result
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Aggregate results from parallel agents",
@@ -422,6 +472,10 @@ Examples:
                 output["stats"]["failed_files"] = failed_files
             if args.validate_schema and status_counts:
                 output["stats"]["status_breakdown"] = dict(status_counts)
+            # Cost/perf rollup (P1-C): sum metrics.* across envelope-shaped inputs.
+            cost_rollup = _rollup_metrics(results)
+            if cost_rollup:
+                output["stats"]["metrics_rollup"] = cost_rollup
     else:
         output = aggregated
     

--- a/scripts/spawn_oz.py
+++ b/scripts/spawn_oz.py
@@ -87,6 +87,10 @@ class OzAgentResult:
     pr_url: Optional[str] = None
     branch: Optional[str] = None
     raw_run_get: Optional[dict] = field(default=None, repr=False)
+    # Cost / perf metrics extracted from `oz run get` (P1-C)
+    tokens_used: Optional[int] = None
+    cost_usd: Optional[float] = None
+    model: Optional[str] = None
 
     @property
     def duration_seconds(self) -> Optional[float]:
@@ -113,9 +117,68 @@ class OzAgentResult:
         }
         if self.error:
             env["error"] = self.error
+        metrics: dict = {}
         if self.duration_seconds is not None:
-            env["metrics"] = {"duration_seconds": self.duration_seconds}
+            metrics["duration_seconds"] = self.duration_seconds
+        if self.tokens_used is not None:
+            metrics["tokens_used"] = self.tokens_used
+        if self.cost_usd is not None:
+            metrics["cost_usd"] = self.cost_usd
+        if self.model:
+            metrics["model"] = self.model
+        if metrics:
+            env["metrics"] = metrics
         return env
+
+
+def _extract_metrics_from_oz(payload: dict) -> dict:
+    """Normalize cost/perf metrics from `oz run get` JSON (P1-C).
+
+    The Oz CLI response shape is not strictly standardized yet; accept a
+    handful of commonly-seen field names so we're resilient to naming drift.
+    Returns a dict with any of: tokens_used (int), cost_usd (float), model (str).
+    """
+    out: dict = {}
+    nested = payload.get("usage") or payload.get("metrics")
+    if isinstance(nested, dict) and nested:
+        tokens = (
+            nested.get("tokens_used")
+            or nested.get("total_tokens")
+            or nested.get("tokens")
+        )
+        cost = (
+            nested.get("cost_usd")
+            or nested.get("cost")
+            or nested.get("total_cost_usd")
+        )
+        model = nested.get("model") or payload.get("model")
+        if isinstance(tokens, (int, float)) and not isinstance(tokens, bool):
+            out["tokens_used"] = int(tokens)
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            out["cost_usd"] = float(cost)
+        if isinstance(model, str):
+            out["model"] = model
+        return out
+    # Flat top-level shape fallback (no nested `usage`/`metrics` dict present)
+    for k_in, k_out, coerce in [
+        ("tokens_used", "tokens_used", int),
+        ("total_tokens", "tokens_used", int),
+        ("cost_usd", "cost_usd", float),
+        ("model", "model", str),
+    ]:
+        v = payload.get(k_in)
+        if v is None or isinstance(v, bool):
+            continue
+        if coerce is str:
+            if isinstance(v, str):
+                out[k_out] = v
+            continue
+        if isinstance(v, (int, float)):
+            try:
+                out[k_out] = coerce(v)
+            except (TypeError, ValueError):
+                continue
+    return out
 
 
 def generate_task_id(task: str, index: int, phase: Optional[str] = None) -> str:
@@ -264,6 +327,14 @@ def wait_for_run(
             result.status = state
             result.raw_run_get = payload
             result.output = payload.get("output") or payload.get("agent_output")
+            # Extract cost/perf metrics (P1-C)
+            metrics = _extract_metrics_from_oz(payload)
+            if "tokens_used" in metrics:
+                result.tokens_used = metrics["tokens_used"]
+            if "cost_usd" in metrics:
+                result.cost_usd = metrics["cost_usd"]
+            if "model" in metrics:
+                result.model = metrics["model"]
             # Look for PR artifact mentions in output
             if result.output:
                 pr_match = re.search(

--- a/tests/test_oz_metrics.py
+++ b/tests/test_oz_metrics.py
@@ -1,0 +1,141 @@
+"""Tests for P1-C: Oz cost/metrics surface.
+
+Covers:
+- `_extract_metrics_from_oz` across response shape variants
+- `wait_for_run` populates OzAgentResult.tokens_used/cost_usd/model
+- `to_envelope` includes metrics in result-schema envelope
+- `_rollup_metrics` sums totals and builds per-model breakdown
+"""
+from __future__ import annotations
+
+from scripts import spawn_oz
+from scripts import aggregate_results
+
+
+class TestExtractMetricsFromOz:
+    def test_usage_nested_object(self):
+        payload = {
+            "status": "succeeded",
+            "usage": {
+                "tokens_used": 1234,
+                "cost_usd": 0.0456,
+                "model": "claude-opus-4",
+            },
+        }
+        out = spawn_oz._extract_metrics_from_oz(payload)
+        assert out == {"tokens_used": 1234, "cost_usd": 0.0456, "model": "claude-opus-4"}
+
+    def test_metrics_nested_alternative(self):
+        payload = {"metrics": {"total_tokens": 500, "cost": 0.01, "model": "gpt-4"}}
+        out = spawn_oz._extract_metrics_from_oz(payload)
+        assert out["tokens_used"] == 500
+        assert out["cost_usd"] == 0.01
+        assert out["model"] == "gpt-4"
+
+    def test_flat_fallback(self):
+        payload = {"tokens_used": 100, "cost_usd": 0.001, "model": "sonnet"}
+        out = spawn_oz._extract_metrics_from_oz(payload)
+        assert out == {"tokens_used": 100, "cost_usd": 0.001, "model": "sonnet"}
+
+    def test_empty_payload(self):
+        assert spawn_oz._extract_metrics_from_oz({}) == {}
+
+    def test_partial_usage(self):
+        payload = {"usage": {"tokens_used": 42}}
+        out = spawn_oz._extract_metrics_from_oz(payload)
+        assert out == {"tokens_used": 42}
+
+    def test_bad_types_ignored(self):
+        payload = {"usage": {"tokens_used": "oops", "cost_usd": "nan", "model": 123}}
+        out = spawn_oz._extract_metrics_from_oz(payload)
+        # model requires str; tokens/cost require numeric — all filtered out
+        assert out == {}
+
+
+class TestWaitForRunPopulatesMetrics:
+    def test_populates_fields_on_success(self, monkeypatch):
+        r = spawn_oz.OzAgentResult(
+            task_id="t1", task="x", run_id="abc", status="running", start_time=1.0
+        )
+
+        def fake_poll(run_id):
+            return {
+                "status": "succeeded",
+                "output": "",
+                "usage": {"tokens_used": 777, "cost_usd": 0.12, "model": "claude-opus-4"},
+            }
+
+        monkeypatch.setattr(spawn_oz, "poll_run", fake_poll)
+        monkeypatch.setattr(spawn_oz.time, "sleep", lambda _s: None)
+        result = spawn_oz.wait_for_run(r, poll_sec=0.0, max_wait_sec=5)
+        assert result.tokens_used == 777
+        assert result.cost_usd == 0.12
+        assert result.model == "claude-opus-4"
+
+
+class TestEnvelopeIncludesMetrics:
+    def test_envelope_surfaces_metrics(self):
+        r = spawn_oz.OzAgentResult(
+            task_id="t1",
+            task="x",
+            run_id="abc",
+            status="succeeded",
+            start_time=1.0,
+            end_time=3.0,
+            tokens_used=100,
+            cost_usd=0.05,
+            model="sonnet",
+        )
+        env = r.to_envelope()
+        assert env["metrics"]["tokens_used"] == 100
+        assert env["metrics"]["cost_usd"] == 0.05
+        assert env["metrics"]["model"] == "sonnet"
+        assert env["metrics"]["duration_seconds"] == 2.0
+
+    def test_envelope_omits_metrics_when_empty(self):
+        r = spawn_oz.OzAgentResult(
+            task_id="t1", task="x", run_id="abc", status="running"
+        )
+        env = r.to_envelope()
+        assert "metrics" not in env
+
+
+class TestRollupMetrics:
+    def test_empty_input_returns_empty(self):
+        assert aggregate_results._rollup_metrics([]) == {}
+
+    def test_non_envelope_inputs_ignored(self):
+        assert aggregate_results._rollup_metrics(["not a dict", {"no_metrics": 1}]) == {}
+
+    def test_sums_tokens_and_cost(self):
+        results = [
+            {"metrics": {"tokens_used": 100, "cost_usd": 0.01, "model": "gpt-4"}},
+            {"metrics": {"tokens_used": 250, "cost_usd": 0.03, "model": "gpt-4"}},
+        ]
+        rollup = aggregate_results._rollup_metrics(results)
+        assert rollup["total_tokens"] == 350
+        assert rollup["total_cost_usd"] == 0.04
+        assert "gpt-4" in rollup["per_model"]
+        assert rollup["per_model"]["gpt-4"]["count"] == 2
+        assert rollup["per_model"]["gpt-4"]["tokens_used"] == 350
+
+    def test_per_model_breakdown(self):
+        results = [
+            {"metrics": {"tokens_used": 100, "cost_usd": 0.01, "model": "claude"}},
+            {"metrics": {"tokens_used": 200, "cost_usd": 0.02, "model": "gpt-4"}},
+            {"metrics": {"tokens_used": 50, "cost_usd": 0.005, "model": "claude"}},
+        ]
+        rollup = aggregate_results._rollup_metrics(results)
+        assert rollup["per_model"]["claude"]["count"] == 2
+        assert rollup["per_model"]["claude"]["tokens_used"] == 150
+        assert rollup["per_model"]["gpt-4"]["count"] == 1
+        assert rollup["per_model"]["gpt-4"]["tokens_used"] == 200
+
+    def test_duration_only_metrics(self):
+        """When only duration is present (no tokens/cost), still surface the rollup."""
+        results = [{"metrics": {"duration_seconds": 1.5}}, {"metrics": {"duration_seconds": 2.5}}]
+        rollup = aggregate_results._rollup_metrics(results)
+        assert rollup["total_duration_seconds"] == 4.0
+        # No total_tokens / total_cost should appear
+        assert "total_tokens" not in rollup
+        assert "total_cost_usd" not in rollup


### PR DESCRIPTION
Extracts and normalizes cost/perf metrics from `oz run get`, carries them into the result envelope, and surfaces totals + per-model breakdown in aggregation stats.

## Highlights
- `spawn_oz.py`: `OzAgentResult` gains `tokens_used`/`cost_usd`/`model`; new `_extract_metrics_from_oz` handles nested `usage`/`metrics` and flat top-level response shapes; `to_envelope` plumbs through.
- `aggregate_results.py`: new `_rollup_metrics(results)` builds `stats.metrics_rollup` with `total_tokens`, `total_cost_usd`, `total_duration_seconds`, and a `per_model` breakdown.

## Tests
+14 tests. **243/243 passing** (up from 229).

## Compatibility
No behavior change when inputs lack `metrics`; rollup silently omitted.

Conversation: https://app.warp.dev/conversation/eafbfe6f-cef2-4e02-84be-720ef9f77c1f

Co-Authored-By: Oz <oz-agent@warp.dev>