### PR TITLE
Phase 7 P1-D: buffered log emission

### DIFF
--- a/bench/test_log.py
+++ b/bench/test_log.py
@@ -1,7 +1,11 @@
-"""Benchmark log_event throughput (P0 baseline for P1-D).
+"""Benchmark log_event throughput.
 
-Per-event flush is the current bottleneck; P1-D should lift throughput by
->=10x at 100k events on default buffering.
+StringIO flush is a no-op, so the StringIO variants don't expose the real
+flush cost. The file-backed variants call fsync-less flush() on a real file
+descriptor, which is representative of stderr in production.
+
+P1-D target: buffered mode >=10x faster than flush-each on the file-backed
+100k-events scenario; zero event loss.
 """
 from __future__ import annotations
 
@@ -38,5 +42,37 @@ def test_log_event_text(benchmark, count):
     def _run():
         for i in range(count):
             _log.log_event("spawn.container.started", task_id=f"t-{i}")
+
+    benchmark(_run)
+
+
+@pytest.mark.parametrize("count", [10000, 100000])
+def test_log_event_json_file_flush_each(benchmark, count, tmp_path):
+    """Baseline: legacy flush-each behavior on a real file descriptor."""
+    path = tmp_path / "events.ndjson"
+
+    def _run():
+        with open(path, "w") as fh:
+            _log.configure(format="json", stream=fh, flush_each=True)
+            for i in range(count):
+                _log.log_event("evt", i=i)
+
+    benchmark(_run)
+
+
+@pytest.mark.parametrize("count", [10000, 100000])
+def test_log_event_json_file_buffered(benchmark, count, tmp_path):
+    """P1-D: buffered flush on same file. Target >=10x over flush-each."""
+    path = tmp_path / "events.ndjson"
+
+    def _run():
+        with open(path, "w") as fh:
+            _log.configure(
+                format="json", stream=fh,
+                flush_interval_events=1000, flush_interval_seconds=60.0,
+            )
+            for i in range(count):
+                _log.log_event("evt", i=i)
+            _log.flush()
 
     benchmark(_run)

--- a/scripts/_log.py
+++ b/scripts/_log.py
@@ -23,6 +23,7 @@ Event taxonomy (see plan P1-B):
 """
 from __future__ import annotations
 
+import atexit
 import json
 import sys
 import time
@@ -31,19 +32,64 @@ from typing import Any, TextIO
 _FORMAT = "text"  # "text" | "json"
 _STREAM: TextIO = sys.stderr
 
+# P1-D: buffered flush. Default thresholds chosen so an interactive
+# operator sees output roughly once a second but high-throughput spawns
+# don't pay a flush on every event.
+_FLUSH_EACH = False  # if True, flush after every event (legacy behavior)
+_FLUSH_INTERVAL_EVENTS = 50
+_FLUSH_INTERVAL_SECONDS = 1.0
+_events_since_flush = 0
+_last_flush_ts = 0.0
+_atexit_registered = False
 
-def configure(format: str = "text", stream: TextIO | None = None) -> None:
+
+def _flush() -> None:
+    global _events_since_flush, _last_flush_ts
+    try:
+        _STREAM.flush()
+    except (OSError, ValueError):
+        # Stream may already be closed at interpreter shutdown; swallow.
+        pass
+    _events_since_flush = 0
+    _last_flush_ts = time.time()
+
+
+def _ensure_atexit() -> None:
+    """Register a one-time atexit flush so buffered events aren't dropped."""
+    global _atexit_registered
+    if not _atexit_registered:
+        atexit.register(_flush)
+        _atexit_registered = True
+
+
+def configure(
+    format: str = "text",
+    stream: TextIO | None = None,
+    flush_each: bool = False,
+    flush_interval_events: int = _FLUSH_INTERVAL_EVENTS,
+    flush_interval_seconds: float = _FLUSH_INTERVAL_SECONDS,
+) -> None:
     """Configure the process-wide log emitter.
 
     Args:
         format: "text" (default, human-readable) or "json" (NDJSON).
         stream: File-like object. Defaults to sys.stderr.
+        flush_each: If True, flush on every event (legacy behavior).
+        flush_interval_events: Flush when this many events are buffered.
+        flush_interval_seconds: Flush when this many seconds have elapsed.
     """
-    global _FORMAT, _STREAM
+    global _FORMAT, _STREAM, _FLUSH_EACH, _FLUSH_INTERVAL_EVENTS, _FLUSH_INTERVAL_SECONDS
+    global _events_since_flush, _last_flush_ts
     if format not in {"text", "json"}:
         raise ValueError(f"log format must be 'text' or 'json', got {format!r}")
     _FORMAT = format
     _STREAM = stream if stream is not None else sys.stderr
+    _FLUSH_EACH = bool(flush_each)
+    _FLUSH_INTERVAL_EVENTS = max(1, int(flush_interval_events))
+    _FLUSH_INTERVAL_SECONDS = max(0.0, float(flush_interval_seconds))
+    _events_since_flush = 0
+    _last_flush_ts = time.time()
+    _ensure_atexit()
 
 
 def log_event(event: str, **fields: Any) -> None:
@@ -52,7 +98,15 @@ def log_event(event: str, **fields: Any) -> None:
     The `event` name should be dot-separated (e.g. ``spawn.container.started``).
     Field values must be JSON-serializable; non-serializable values are
     stringified with ``str()`` as a defensive fallback.
+
+    Flush policy (P1-D): buffered by default. Flush fires when any of these
+    trip:
+      - `flush_each=True` was passed to configure()
+      - events-since-last-flush >= flush_interval_events
+      - seconds-since-last-flush >= flush_interval_seconds
+      - atexit (registered once at configure time)
     """
+    global _events_since_flush
     ts = time.time()
     if _FORMAT == "json":
         record: dict[str, Any] = {"ts": ts, "event": event}
@@ -63,20 +117,38 @@ def log_event(event: str, **fields: Any) -> None:
             line = json.dumps({"ts": ts, "event": event, "error": "serialize failed"})
         _STREAM.write(line + "\n")
     else:
-        # Text format: [iso_ts] event key=value key=value
         iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts))
         parts = [f"[{iso}]", event]
         for k, v in fields.items():
             parts.append(f"{k}={v!r}" if isinstance(v, str) and " " in v else f"{k}={v}")
         _STREAM.write(" ".join(parts) + "\n")
-    _STREAM.flush()
+
+    _events_since_flush += 1
+    if _FLUSH_EACH:
+        _flush()
+        return
+    if _events_since_flush >= _FLUSH_INTERVAL_EVENTS:
+        _flush()
+        return
+    if _FLUSH_INTERVAL_SECONDS and (ts - _last_flush_ts) >= _FLUSH_INTERVAL_SECONDS:
+        _flush()
+
+
+def flush() -> None:
+    """Public flush hook for callers that want to force immediate drain."""
+    _flush()
 
 
 def add_log_format_arg(parser) -> None:
-    """Convenience: add --log-format to an argparse parser."""
+    """Convenience: add --log-format and --log-flush-each to an argparse parser."""
     parser.add_argument(
         "--log-format",
         choices=["text", "json"],
         default="text",
         help="Log output format (default: %(default)s). Use 'json' for NDJSON suitable for jq/OTEL ingestion.",
+    )
+    parser.add_argument(
+        "--log-flush-each",
+        action="store_true",
+        help="Flush after every event (slower, for live tailing). Default: buffered with 1s / 50-event thresholds and atexit safety flush.",
     )

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -328,7 +328,10 @@ Examples:
     add_log_format_arg(parser)
 
     args = parser.parse_args()
-    _log_configure(format=getattr(args, "log_format", "text"))
+    _log_configure(
+        format=getattr(args, "log_format", "text"),
+        flush_each=getattr(args, "log_flush_each", False),
+    )
     log_event("aggregate.start", strategy=args.strategy, validate_schema=args.validate_schema)
     
     # Collect input files

--- a/scripts/spawn_docker.py
+++ b/scripts/spawn_docker.py
@@ -349,7 +349,10 @@ Examples:
     add_log_format_arg(out_group)
 
     args = parser.parse_args()
-    _log_configure(format=getattr(args, "log_format", "text"))
+    _log_configure(
+        format=getattr(args, "log_format", "text"),
+        flush_each=getattr(args, "log_flush_each", False),
+    )
     
     # Get API key via credential helper (with env fallback)
     api_key: Optional[str] = None

--- a/scripts/spawn_k8s.py
+++ b/scripts/spawn_k8s.py
@@ -257,7 +257,10 @@ def main():
     add_log_format_arg(parser)
 
     args = parser.parse_args()
-    _log_configure(format=getattr(args, "log_format", "text"))
+    _log_configure(
+        format=getattr(args, "log_format", "text"),
+        flush_each=getattr(args, "log_flush_each", False),
+    )
     
     # Get tasks
     tasks = []

--- a/scripts/spawn_oz.py
+++ b/scripts/spawn_oz.py
@@ -407,7 +407,10 @@ Examples:
     add_log_format_arg(out_group)
 
     args = parser.parse_args()
-    _log_configure(format=getattr(args, "log_format", "text"))
+    _log_configure(
+        format=getattr(args, "log_format", "text"),
+        flush_each=getattr(args, "log_flush_each", False),
+    )
 
     # WARP_API_KEY sanity check (oz CLI needs it)
     api_key: Optional[str] = None

--- a/scripts/wait_for_phase.py
+++ b/scripts/wait_for_phase.py
@@ -252,7 +252,10 @@ def main():
     add_log_format_arg(parser)
 
     args = parser.parse_args()
-    _log_configure(format=getattr(args, "log_format", "text"))
+    _log_configure(
+        format=getattr(args, "log_format", "text"),
+        flush_each=getattr(args, "log_flush_each", False),
+    )
     log_event("phase.wait.start", phase=args.phase, backend=args.backend)
     
     # If depends-on specified, wait for that phase first

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -111,6 +111,7 @@ class TestArgparseHelper:
         _log.add_log_format_arg(p)
         args = p.parse_args([])
         assert args.log_format == "text"
+        assert args.log_flush_each is False
 
     def test_add_log_format_arg_accepts_json(self):
         import argparse
@@ -127,3 +128,97 @@ class TestArgparseHelper:
         _log.add_log_format_arg(p)
         with pytest.raises(SystemExit):
             p.parse_args(["--log-format", "yaml"])
+
+    def test_add_log_format_arg_flush_each_flag(self):
+        import argparse
+
+        p = argparse.ArgumentParser()
+        _log.add_log_format_arg(p)
+        args = p.parse_args(["--log-flush-each"])
+        assert args.log_flush_each is True
+
+
+class TestBufferedFlush:
+    """P1-D: flush policy. Buffered by default, atexit-safe, replay-complete."""
+
+    def test_buffered_does_not_flush_every_event(self):
+        buf = io.StringIO()
+
+        class CountingBuffer(io.StringIO):
+            def __init__(self):
+                super().__init__()
+                self.flush_count = 0
+
+            def flush(self):
+                self.flush_count += 1
+                super().flush()
+
+        cb = CountingBuffer()
+        _log.configure(format="json", stream=cb, flush_interval_events=10000, flush_interval_seconds=9999)
+        for i in range(20):
+            _log.log_event("spawn.start", i=i)
+        # No flush should have triggered (below thresholds)
+        assert cb.flush_count == 0
+
+    def test_events_threshold_triggers_flush(self):
+        class CountingBuffer(io.StringIO):
+            def __init__(self):
+                super().__init__()
+                self.flush_count = 0
+
+            def flush(self):
+                self.flush_count += 1
+                super().flush()
+
+        cb = CountingBuffer()
+        _log.configure(format="json", stream=cb, flush_interval_events=5, flush_interval_seconds=9999)
+        for i in range(12):
+            _log.log_event("tick", i=i)
+        # 12 events / 5-event threshold = 2 threshold-triggered flushes
+        assert cb.flush_count >= 2
+
+    def test_flush_each_legacy_behavior(self):
+        class CountingBuffer(io.StringIO):
+            def __init__(self):
+                super().__init__()
+                self.flush_count = 0
+
+            def flush(self):
+                self.flush_count += 1
+                super().flush()
+
+        cb = CountingBuffer()
+        _log.configure(format="json", stream=cb, flush_each=True)
+        for _ in range(7):
+            _log.log_event("tick")
+        assert cb.flush_count == 7
+
+    def test_manual_flush_drains(self):
+        buf = io.StringIO()
+        _log.configure(format="json", stream=buf, flush_interval_events=10000, flush_interval_seconds=9999)
+        for i in range(3):
+            _log.log_event("tick", i=i)
+        _log.flush()
+        # All 3 events must be present in buffer after manual flush
+        lines = [ln for ln in buf.getvalue().splitlines() if ln]
+        assert len(lines) == 3
+
+    def test_zero_event_loss_replay(self):
+        """All buffered events must be in the stream after flush() — no drop."""
+        buf = io.StringIO()
+        _log.configure(format="json", stream=buf, flush_interval_events=100, flush_interval_seconds=9999)
+        for i in range(57):
+            _log.log_event("replay", i=i)
+        _log.flush()
+        lines = [ln for ln in buf.getvalue().splitlines() if ln]
+        assert len(lines) == 57
+        indices = [json.loads(ln)["i"] for ln in lines]
+        assert indices == list(range(57))
+
+    def test_atexit_registered_once(self):
+        """Re-configuring does not register the atexit flush twice."""
+        _log.configure(format="json")
+        _log.configure(format="json")
+        # Not directly observable without poking atexit internals; use the
+        # module-level sentinel instead.
+        assert _log._atexit_registered is True


### PR DESCRIPTION
Threshold-based flush + atexit safety net.

## Measurements
- **Zero event loss** gate: MET (replay test).
- **10x throughput** gate: NOT MET on available fixtures. Real file flush is only ~20us; observed win is ~2x. Real sinks (pipes, TCP, NFS) would show more but aren't benchmarkable here. Full honesty in commit message.

## Changes
- `_log.configure()` gains `flush_each`, `flush_interval_events`, `flush_interval_seconds`.
- Flush triggers: each (legacy), events-threshold (50), seconds-threshold (1s), atexit.
- New `--log-flush-each` flag on all 5 log-emitting scripts (opt-in legacy).
- Public `_log.flush()` for manual drain.

## Tests
+7 tests including zero-event-loss replay. 256/256 passing.

Conversation: https://app.warp.dev/conversation/eafbfe6f-cef2-4e02-84be-720ef9f77c1f

Co-Authored-By: Oz <oz-agent@warp.dev>