### PR TITLE
phase7/p1-a: streaming aggregation + --max-memory-mb spillover

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          pip install -e .
           pip install pytest pytest-cov
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to the **multi-agent-workflows** skill are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] — 2026-04-19
+## [Unreleased]
+Phase 7 (scalability/perf). Work-in-progress release; numbers finalized at v1.2.0.
+### Added
+- **Streaming aggregation** (phase 7 P1-A) — `scripts/aggregate_results.py` now loads input files through `iter_loaded_files` (bounded-window `ThreadPoolExecutor`) and folds the merge/concat accumulators directly over the stream. The pre-existing `list(executor.map(load_file, files))` materialization is gone. `_IncrementalRollup` accumulates metrics inline during the load so `--include-stats` no longer requires a second pass.
+- **`--max-memory-mb`** flag on `aggregate_results.py` — per-envelope `data` payloads that serialize above the budget are replaced with `{artifact_path, artifact_size}` pointers per `references/result-schema.md` "Non-envelope outputs". The envelope itself is never mutated; the pointer is written to a shallow copy. Spill count surfaces as `stats.spilled_payloads` and a new `aggregate.spill` structured-log event.
+- **`--load-workers`** flag to control the streaming loader concurrency (default 8).
+- **Bench scenario** `bench/test_streaming_aggregation.py` — measures disk-backed merge throughput and peak memory for materialized vs streaming at 1k/10k. Memory numbers landed in `bench/RESULTS.md`.
+### Changed
+- `merge_dicts` / `strategy_merge` / `strategy_concat` / `_rollup_metrics` now accept any `Iterable`. List callers are unaffected (semantically identical for `last`/`first`/`concat`/`error` policies); generator callers work without a materialization step.
 Phase 6: cloud-native orchestration + production hardening.
 ### Added
 - **`spawn_oz.py`** (P0-A) — cloud-agent backend using `oz agent run-cloud`; required `--environment`; fire-and-forget by default with opt-in `--wait` polling; captures PR/branch artifacts from agent output; new `maw-spawn-oz` entry point.

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -53,3 +53,28 @@ pytest bench/ --benchmark-only --benchmark-compare=bench/baseline.json \
               --benchmark-compare-fail=mean:10%
 ```
 Fails if any benchmark regresses more than 10% vs baseline.
+## Phase 7 P1-A — streaming aggregation
+Disk-backed merge: the plan's 5x throughput gate was overly optimistic. JSON parsing of N files dominates both code paths and the bounded-window producer/consumer in `iter_loaded_files` adds a small amount of futures/queue overhead vs the pre-change `list(executor.map(...))`. The win P1-A actually delivers is **flat, O(1) peak memory** regardless of corpus size.
+### Wall-clock (macOS arm64, Python 3.14.4)
+| Pipeline                             | N      | Mean      |
+|--------------------------------------|--------|-----------|
+| `_materialized_merge` (pre-P1-A)     | 1000   | ~65.7 ms  |
+| `_materialized_merge` (pre-P1-A)     | 10000  | ~631 ms   |
+| `_streaming_merge` (post-P1-A)       | 1000   | ~63.8 ms  |
+| `_streaming_merge` (post-P1-A)       | 10000  | ~662 ms   |
+| `_materialized_merge_with_validation`| 1000   | ~96.1 ms  |
+| `_streaming_merge_with_validation`   | 1000   | ~116.6 ms |
+Throughput is within noise (±5%) on pure merge; the validation path is slightly slower in streaming mode due to interleaving of load + validate in a single pass. Acceptable given the memory profile below.
+### Peak memory (tracemalloc, from repo venv)
+| N      | Materialized | Streaming | Ratio   |
+|--------|--------------|-----------|---------|
+| 1,000  | 3,299 KiB    | 1,158 KiB | 2.85x   |
+| 5,000  | 11,506 KiB   | 1,160 KiB | 9.92x   |
+| 10,000 | 21,813 KiB   | 1,164 KiB | 18.73x  |
+Streaming peak is **constant** (~1.16 MiB). Materialized peak grows linearly with N. At 10k envelopes we hold 18.7x less, and the ratio keeps improving as the corpus scales. The `test_peak_memory_streaming_lower_than_materialized` bench asserts a 2x gap as a machine-portable regression guard.
+### `--max-memory-mb` spillover
+No throughput penalty observed when the budget is not exceeded (cost is one `json.dumps(data)` per envelope). Payloads above budget write an `{artifact_path, artifact_size}` pointer; the original file on disk is untouched so consumers can re-hydrate.
+### Honest gate assessment
+- Plan gate: "≥5x throughput on 10k". **Not met** — throughput is effectively parity.
+- Memory gate (implicit in plan: "memory RSS capped at a configurable ceiling"). **Met** — flat ~1.16 MiB peak; `--max-memory-mb` provides explicit per-envelope cap.
+- Recommendation: keep the streaming refactor for the memory profile; treat the throughput gate as a future P2 if the need arises (would require async I/O or skipping JSON re-parse in hot paths).

--- a/bench/test_streaming_aggregation.py
+++ b/bench/test_streaming_aggregation.py
@@ -1,0 +1,149 @@
+"""Phase 7 P1-A: disk-backed aggregation (streaming vs materialized).
+
+The P0 baseline benchmarks already cover in-memory strategy hot paths. Those
+numbers say nothing about the pipeline we actually ship, which is:
+  1. discover N files,
+  2. parse JSON from disk,
+  3. (optionally) validate,
+  4. fold into an accumulator.
+
+The materialized path that used to live in ``aggregate_results.main`` builds a
+full ``list(executor.map(load_file, files))`` and then iterates. The streaming
+path built in P1-A threads ``iter_loaded_files`` directly into ``strategy_merge``
+so no intermediate list exists. These benchmarks measure both so we can
+document the throughput delta and guarantee we don't regress back to O(N) RAM.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from scripts.aggregate_results import (
+    _load_one,
+    iter_loaded_files,
+    load_json_file,
+    strategy_merge,
+)
+
+
+def _materialized_merge(files):
+    """Baseline-equivalent of pre-P1-A main(): list-materialize then merge."""
+    with ThreadPoolExecutor(max_workers=min(8, max(1, len(files)))) as ex:
+        loaded = list(ex.map(_load_one, files))
+    return strategy_merge([d for _, d in loaded if d is not None])
+
+
+def _streaming_merge(files):
+    """P1-A path: stream envelopes directly into the merge accumulator."""
+    return strategy_merge(
+        d for _, d in iter_loaded_files(files, max_workers=8) if d is not None
+    )
+
+
+@pytest.mark.parametrize("count", [1000, 10000])
+def test_disk_merge_materialized_baseline(benchmark, tmp_path, envelope_factory, count):
+    root = envelope_factory.write_dir(tmp_path / "env", count, failure_rate=0.0)
+    files = sorted(root.rglob("result.json"))
+    benchmark(_materialized_merge, files)
+
+
+@pytest.mark.parametrize("count", [1000, 10000])
+def test_disk_merge_streaming(benchmark, tmp_path, envelope_factory, count):
+    root = envelope_factory.write_dir(tmp_path / "env", count, failure_rate=0.0)
+    files = sorted(root.rglob("result.json"))
+    benchmark(_streaming_merge, files)
+
+
+def test_streaming_does_not_materialize_full_list(tmp_path, envelope_factory):
+    """Smoke check: pulling one item from the stream should not force-load the rest."""
+    root = envelope_factory.write_dir(tmp_path / "env", 50, failure_rate=0.0)
+    files = sorted(root.rglob("result.json"))
+    it = iter_loaded_files(files, max_workers=4)
+    first = next(it)
+    assert first[1]["status"] in {"ok", "failed"}
+    # Drain so the pool shuts down cleanly.
+    remaining = list(it)
+    assert len(remaining) == 49
+
+
+def _peak_kib(fn, *args, **kwargs):
+    import tracemalloc
+
+    tracemalloc.start()
+    try:
+        fn(*args, **kwargs)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    return peak / 1024
+
+
+def test_peak_memory_streaming_lower_than_materialized(tmp_path, envelope_factory):
+    """Headline P1-A win: stream peak RSS is materially smaller than materialized.
+
+    We only assert a 2x gap so the test stays stable across machines; the
+    actual ratio at 10k envelopes is typically 5-10x in practice, and the exact
+    numbers are tracked in bench/RESULTS.md.
+    """
+    root = envelope_factory.write_dir(tmp_path / "env", 2000, failure_rate=0.0)
+    files = sorted(root.rglob("result.json"))
+    mat = _peak_kib(_materialized_merge, files)
+    stream = _peak_kib(_streaming_merge, files)
+    # Sanity: both > 0, streaming clearly lower.
+    assert stream > 0 and mat > 0
+    assert stream * 2 < mat, (
+        f"expected streaming peak << materialized peak, got stream={stream:.1f} KiB "
+        f"vs materialized={mat:.1f} KiB"
+    )
+
+
+def _materialized_merge_with_validation(files, schema):
+    """Pre-P1-A shape: load-all, then a SECOND pass validating each envelope."""
+    from scripts.schema_validator import validate_envelope
+
+    with ThreadPoolExecutor(max_workers=min(8, max(1, len(files)))) as ex:
+        loaded = list(ex.map(_load_one, files))
+    kept = []
+    for _, d in loaded:
+        if d is None:
+            continue
+        vr = validate_envelope(d, schema=schema)
+        if vr.ok and d.get("status") != "failed":
+            kept.append(d)
+    return strategy_merge(kept)
+
+
+def _streaming_merge_with_validation(files, schema):
+    """P1-A shape: fold load + validate into a single pass."""
+    from scripts.schema_validator import validate_envelope
+
+    def gen():
+        for _, d in iter_loaded_files(files, max_workers=8):
+            if d is None:
+                continue
+            vr = validate_envelope(d, schema=schema)
+            if vr.ok and d.get("status") != "failed":
+                yield d
+
+    return strategy_merge(gen())
+
+
+@pytest.mark.parametrize("count", [1000])
+def test_validation_materialized(benchmark, tmp_path, envelope_factory, count):
+    from scripts.schema_validator import _load_schema
+
+    root = envelope_factory.write_dir(tmp_path / "env", count, failure_rate=0.0)
+    files = sorted(root.rglob("result.json"))
+    schema = _load_schema()
+    benchmark(_materialized_merge_with_validation, files, schema)
+
+
+@pytest.mark.parametrize("count", [1000])
+def test_validation_streaming(benchmark, tmp_path, envelope_factory, count):
+    from scripts.schema_validator import _load_schema
+
+    root = envelope_factory.write_dir(tmp_path / "env", count, failure_rate=0.0)
+    files = sorted(root.rglob("result.json"))
+    schema = _load_schema()
+    benchmark(_streaming_merge_with_validation, files, schema)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ include = ["scripts*"]
 [tool.ruff]
 target-version = "py310"
 line-length = 120
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings
@@ -71,7 +73,7 @@ ignore = [
     "E501",  # line too long (handled by formatter)
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["B011"]
 
 [tool.black]

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -4,6 +4,7 @@ Kept module-private (leading underscore) so it's clear this is internal
 plumbing, not part of the public script surface. Each spawn_* script
 imports from here to avoid duplicating fault-tolerance logic.
 """
+
 from __future__ import annotations
 
 import random
@@ -20,7 +21,7 @@ class _HasStatus(Protocol):
 
 def calculate_backoff(retry: int, base_delay: float = 2.0, max_delay: float = 60.0) -> float:
     """Exponential backoff with 10% jitter. retry is 0-indexed."""
-    delay = min(base_delay * (2 ** retry), max_delay)
+    delay = min(base_delay * (2**retry), max_delay)
     jitter = delay * 0.1 * random.random()
     return delay + jitter
 
@@ -73,11 +74,7 @@ def validate_tasks_file(path: Path) -> list[str]:
     if not path.exists():
         print(f"Error: Tasks file not found: {path}", file=sys.stderr)
         sys.exit(1)
-    tasks = [
-        line.strip()
-        for line in path.read_text().splitlines()
-        if line.strip() and not line.startswith("#")
-    ]
+    tasks = [line.strip() for line in path.read_text().splitlines() if line.strip() and not line.startswith("#")]
     if not tasks:
         print(f"Error: No tasks found in {path}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/_log.py
+++ b/scripts/_log.py
@@ -21,6 +21,7 @@ Event taxonomy (see plan P1-B):
     phase.wait.start, phase.wait.done,
     aggregate.start, aggregate.done
 """
+
 from __future__ import annotations
 
 import atexit

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -14,21 +14,24 @@ import collections
 import json
 import sys
 from collections import Counter
-from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator, Optional, Tuple, TypeVar
 
 # Structured logging (optional; degrades gracefully if unavailable)
 try:
-    from scripts._log import configure as _log_configure, log_event, add_log_format_arg  # type: ignore
+    from scripts._log import add_log_format_arg, log_event
+    from scripts._log import configure as _log_configure  # type: ignore
 except ImportError:
     try:
-        from ._log import configure as _log_configure, log_event, add_log_format_arg  # type: ignore
+        from ._log import add_log_format_arg, log_event
+        from ._log import configure as _log_configure  # type: ignore
     except ImportError:
+
         def _log_configure(*_a, **_k): ...
         def log_event(*_a, **_k): ...
         def add_log_format_arg(_p): ...
+
 
 T = TypeVar("T")
 
@@ -51,20 +54,20 @@ def load_text_file(path: Path) -> Optional[str]:
 
 def find_result_files(input_dir: Path, pattern: str = "result.json") -> list[Path]:
     """Find all result files in the input directory.
-    
+
     Search order: exact pattern match > any .json > any .md
     """
     # Direct files matching pattern
     results = list(input_dir.glob(f"**/{pattern}"))
-    
+
     # Fallback to any JSON files
     if not results:
         results = list(input_dir.glob("**/*.json"))
-    
+
     # Fallback to markdown files for concat strategy
     if not results:
         results = list(input_dir.glob("**/*.md"))
-    
+
     return sorted(results)
 
 
@@ -200,7 +203,7 @@ def strategy_concat(
                 text_results.append(json.dumps(r, indent=2))
         else:
             text_results.append(str(r))
-    
+
     return separator.join(text_results)
 
 
@@ -215,7 +218,7 @@ def strategy_vote(
     """Vote strategy: use majority for boolean/choice outputs."""
     votes = []
     confidences = []
-    
+
     for r in results:
         if vote_field in r:
             votes.append(r[vote_field])
@@ -223,20 +226,20 @@ def strategy_vote(
                 confidences.append(r[confidence_field])
             else:
                 confidences.append(1.0)
-    
+
     if not votes:
         return {"error": f"No votes found for field: {vote_field}"}
-    
+
     # Count votes (weighted if requested)
     if weighted:
         vote_weights: dict[Any, float] = {}
-        for vote, conf in zip(votes, confidences):
+        for vote, conf in zip(votes, confidences, strict=False):
             key = str(vote)
             vote_weights[key] = vote_weights.get(key, 0) + conf
-        
+
         winner = max(vote_weights.items(), key=lambda x: x[1])
         total_weight = sum(vote_weights.values())
-        
+
         return {
             vote_field: winner[0] == "True" if winner[0] in ("True", "False") else winner[0],
             "vote_weights": vote_weights,
@@ -248,7 +251,7 @@ def strategy_vote(
         counter = Counter(str(v) for v in votes)
         total = len(votes)
         winner, count = counter.most_common(1)[0]
-        
+
         return {
             vote_field: winner == "True" if winner in ("True", "False") else winner,
             "vote_count": dict(counter),
@@ -265,6 +268,7 @@ def strategy_latest(
     **kwargs,
 ) -> dict:
     """Latest strategy: take most recent output per key."""
+
     # Sort by timestamp
     def get_timestamp(r: dict) -> datetime:
         ts = r.get(timestamp_field, "1970-01-01T00:00:00")
@@ -272,9 +276,9 @@ def strategy_latest(
             return datetime.fromisoformat(ts.replace("Z", "+00:00"))
         except Exception:
             return datetime.min
-    
+
     sorted_results = sorted(results, key=get_timestamp, reverse=True)
-    
+
     if sorted_results:
         return sorted_results[0]
     return {}
@@ -329,9 +333,7 @@ class _IncrementalRollup:
         if isinstance(dur, (int, float)):
             self.total_duration += float(dur)
         if isinstance(model, str):
-            bucket = self.per_model.setdefault(
-                model, {"count": 0, "tokens_used": 0, "cost_usd": 0.0}
-            )
+            bucket = self.per_model.setdefault(model, {"count": 0, "tokens_used": 0, "cost_usd": 0.0})
             bucket["count"] += 1
             if isinstance(tokens, (int, float)):
                 bucket["tokens_used"] += int(tokens)
@@ -410,32 +412,38 @@ Examples:
   %(prog)s --input-files a.json b.json c.json -o vote.json --strategy vote --vote-field approved
 """,
     )
-    
+
     # Input options
     input_group = parser.add_argument_group("Input (one required)")
     input_group.add_argument("--input-dir", type=Path, metavar="DIR", help="Directory containing agent outputs")
     input_group.add_argument("--input-files", nargs="+", type=Path, metavar="FILE", help="Specific files to aggregate")
     input_group.add_argument("--pattern", default="result.json", help="File pattern to match (default: %(default)s)")
-    
+
     # Output options
     parser.add_argument("--output", "-o", type=Path, required=True, help="Output file path")
-    parser.add_argument("--format", choices=["json", "yaml", "markdown", "csv"], help="Output format (auto-detected from extension)")
-    
+    parser.add_argument(
+        "--format", choices=["json", "yaml", "markdown", "csv"], help="Output format (auto-detected from extension)"
+    )
+
     # Strategy options
-    parser.add_argument("--strategy", "-s", default="merge", choices=list(STRATEGIES.keys()), help="Aggregation strategy")
-    parser.add_argument("--merge-policy", default="last", choices=["last", "first", "concat", "error"], help="Merge conflict policy")
+    parser.add_argument(
+        "--strategy", "-s", default="merge", choices=list(STRATEGIES.keys()), help="Aggregation strategy"
+    )
+    parser.add_argument(
+        "--merge-policy", default="last", choices=["last", "first", "concat", "error"], help="Merge conflict policy"
+    )
     parser.add_argument("--concat-separator", default="\n\n", help="Separator for concat strategy")
     parser.add_argument("--vote-field", default="decision", help="Field to vote on")
     parser.add_argument("--vote-threshold", type=float, default=0.5, help="Vote threshold for majority")
     parser.add_argument("--vote-weighted", action="store_true", help="Weight votes by confidence")
     parser.add_argument("--timestamp-field", default="timestamp", help="Timestamp field for latest strategy")
-    
+
     # Error handling
     parser.add_argument("--allow-partial", action="store_true", help="Allow partial results (some failures)")
     parser.add_argument("--min-success", type=float, default=0.0, help="Minimum success ratio required")
     parser.add_argument("--strict", action="store_true", help="Fail if any agent failed")
     parser.add_argument("--skip-invalid", action="store_true", help="Skip invalid/unparseable files")
-    
+
     # Metadata
     parser.add_argument("--include-provenance", action="store_true", help="Include source info")
     parser.add_argument("--include-stats", action="store_true", help="Include aggregation statistics")
@@ -445,7 +453,7 @@ Examples:
         "--validate-schema",
         action="store_true",
         help="Validate each input against references/result-schema.json (v1 envelope). "
-             "Drops status=='failed' entries from merge/concat; malformed envelopes abort.",
+        "Drops status=='failed' entries from merge/concat; malformed envelopes abort.",
     )
     # Streaming aggregation / memory cap (phase 7 P1-A)
     parser.add_argument(
@@ -454,8 +462,8 @@ Examples:
         default=None,
         metavar="MB",
         help="Per-envelope data budget. Envelopes whose `data` serializes above this "
-             "MiB threshold are replaced with {artifact_path, artifact_size} pointers "
-             "(see references/result-schema.md). Omit to retain all payloads.",
+        "MiB threshold are replaced with {artifact_path, artifact_size} pointers "
+        "(see references/result-schema.md). Omit to retain all payloads.",
     )
     parser.add_argument(
         "--load-workers",
@@ -472,7 +480,7 @@ Examples:
         flush_each=getattr(args, "log_flush_each", False),
     )
     log_event("aggregate.start", strategy=args.strategy, validate_schema=args.validate_schema)
-    
+
     # Collect input files
     input_files = []
     if args.input_files:
@@ -482,13 +490,13 @@ Examples:
     else:
         print("Error: Must provide --input-dir or --input-files", file=sys.stderr)
         sys.exit(1)
-    
+
     if not input_files:
         print("Error: No input files found", file=sys.stderr)
         sys.exit(1)
-    
+
     print(f"Found {len(input_files)} result files", file=sys.stderr)
-    
+
     # Shared accumulators (mutated during streaming load).
     provenance: dict[str, dict] = {}
     failed_files: list[str] = []
@@ -500,19 +508,17 @@ Examples:
     validate_envelope = None  # bound on demand to keep imports lazy
     if args.validate_schema:
         try:
-            from scripts.schema_validator import validate_envelope, _load_schema  # type: ignore
+            from scripts.schema_validator import _load_schema, validate_envelope  # type: ignore
         except ImportError:
             try:
-                from .schema_validator import validate_envelope, _load_schema  # type: ignore
+                from .schema_validator import _load_schema, validate_envelope  # type: ignore
             except ImportError:
                 sys.path.insert(0, str(Path(__file__).parent))
-                from schema_validator import validate_envelope, _load_schema  # type: ignore
+                from schema_validator import _load_schema, validate_envelope  # type: ignore
         validator_schema = _load_schema()
 
     spill_budget_bytes = (
-        int(args.max_memory_mb * 1024 * 1024)
-        if args.max_memory_mb is not None and args.max_memory_mb > 0
-        else 0
+        int(args.max_memory_mb * 1024 * 1024) if args.max_memory_mb is not None and args.max_memory_mb > 0 else 0
     )
     # Counter incremented inside the streaming generator so vote/latest paths
     # (which materialize) and merge/concat paths (which don't) agree on the
@@ -616,17 +622,17 @@ Examples:
     if successful == 0:
         print("Error: No valid results to aggregate", file=sys.stderr)
         sys.exit(1)
-    
+
     # Build final output
     if args.include_provenance or args.include_stats:
         if isinstance(aggregated, dict):
             output = {"data": aggregated}
         else:
             output = {"data": str(aggregated)}
-        
+
         if args.include_provenance:
             output["provenance"] = provenance
-        
+
         if args.include_stats:
             output["stats"] = {
                 "total_files": total,
@@ -649,7 +655,7 @@ Examples:
                 output["stats"]["spilled_payloads"] = spilled_ref[0]
     else:
         output = aggregated
-    
+
     # Determine output format
     output_format = args.format
     if not output_format:
@@ -662,14 +668,15 @@ Examples:
             ".csv": "csv",
         }
         output_format = format_map.get(suffix, "json")
-    
+
     # Write output
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    
+
     if output_format == "json":
         args.output.write_text(json.dumps(output, indent=2, default=str))
     elif output_format == "yaml":
         import yaml
+
         args.output.write_text(yaml.dump(output, default_flow_style=False))
     elif output_format == "markdown":
         if isinstance(output, str):
@@ -680,6 +687,7 @@ Examples:
             args.output.write_text(json.dumps(output, indent=2, default=str))
     elif output_format == "csv":
         import csv
+
         if isinstance(output, list):
             with open(args.output, "w", newline="") as f:
                 if output and isinstance(output[0], dict):
@@ -689,7 +697,7 @@ Examples:
         else:
             print("Warning: CSV format requires list output, writing as JSON", file=sys.stderr)
             args.output.write_text(json.dumps(output, indent=2, default=str))
-    
+
     print(f"✓ Aggregated {successful} results to {args.output}", file=sys.stderr)
     log_event(
         "aggregate.done",

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -10,12 +10,14 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import collections
 import json
 import sys
 from collections import Counter
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Iterable, Iterator, Optional, Tuple, TypeVar
 
 # Structured logging (optional; degrades gracefully if unavailable)
 try:
@@ -66,14 +68,77 @@ def find_result_files(input_dir: Path, pattern: str = "result.json") -> list[Pat
     return sorted(results)
 
 
-def merge_dicts(dicts: list[dict], policy: str = "last") -> dict:
-    """Merge multiple dictionaries.
+def _load_one(path: Path) -> Tuple[Path, Any]:
+    """Load one file, dispatching on extension. Returns (path, data or None)."""
+    if path.suffix == ".json":
+        return path, load_json_file(path)
+    return path, load_text_file(path)
+
+
+def iter_loaded_files(
+    files: Iterable[Path],
+    max_workers: int = 8,
+    window_multiplier: int = 4,
+) -> Iterator[Tuple[Path, Any]]:
+    """Yield ``(path, data)`` pairs from ``files`` lazily.
+
+    Uses a bounded in-flight window (``max_workers * window_multiplier`` futures)
+    so that memory scales with the window, not with ``len(files)``. This replaces
+    the ``list(executor.map(load_file, input_files))`` materialization that made
+    `aggregate_results.py` O(N) in RAM at 10k+ envelope scale (phase 7 P1-A).
+
+    * ``len(files) <= 10`` or ``max_workers <= 1`` -> sequential fast-path.
+    * Otherwise, a ``ThreadPoolExecutor`` streams results in submission order
+      so downstream merge/concat accumulators can fold them one at a time.
+    """
+    if isinstance(files, list):
+        file_list = files
+    else:
+        file_list = list(files)
+    if not file_list:
+        return
+    if len(file_list) <= 10 or max_workers <= 1:
+        for f in file_list:
+            yield _load_one(f)
+        return
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    workers = max(1, min(max_workers, len(file_list)))
+    window = max(workers, workers * window_multiplier)
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        pending: "collections.deque" = collections.deque()
+        it = iter(file_list)
+        # Prime the window.
+        for _ in range(window):
+            try:
+                f = next(it)
+            except StopIteration:
+                break
+            pending.append(executor.submit(_load_one, f))
+        while pending:
+            fut = pending.popleft()
+            try:
+                f_next = next(it)
+            except StopIteration:
+                f_next = None
+            if f_next is not None:
+                pending.append(executor.submit(_load_one, f_next))
+            yield fut.result()
+
+
+def merge_dicts(dicts: Iterable[dict], policy: str = "last") -> dict:
+    """Merge dictionaries from any iterable (list or lazy iterator).
+
+    Streaming-safe: consumes ``dicts`` once so callers can pass a generator
+    (phase 7 P1-A) without materializing the corpus in memory first.
 
     Fast paths:
       - policy='last'  : chain of dict.update() (C-loop, ~4x faster than pure-Python
         key iteration — see /tmp/maw-bench 'Pass 3' integration results).
-      - policy='first' : iterate in reverse so that earlier dicts overwrite later
-        dicts, giving first-seen-wins semantics with a single dict.update chain.
+      - policy='first' : forward-iterate and skip keys that are already set.
+        Equivalent to the previous ``reversed(dicts) + dict.update`` chain
+        for in-memory inputs (first-seen-wins), but works on iterators.
     Slow path preserved for 'concat' and 'error', which require per-key logic.
     """
     if policy == "last":
@@ -84,8 +149,10 @@ def merge_dicts(dicts: list[dict], policy: str = "last") -> dict:
 
     if policy == "first":
         result = {}
-        for d in reversed(dicts):
-            result.update(d)
+        for d in dicts:
+            for key, value in d.items():
+                if key not in result:
+                    result[key] = value
         return result
 
     # 'concat' and 'error' policies: require per-key inspection.
@@ -103,20 +170,20 @@ def merge_dicts(dicts: list[dict], policy: str = "last") -> dict:
 
 
 def strategy_merge(
-    results: list[dict],
+    results: Iterable[dict],
     merge_policy: str = "last",
     **kwargs,
 ) -> dict:
-    """Merge strategy: combine non-conflicting outputs."""
+    """Merge strategy: combine non-conflicting outputs. Accepts list or iterator."""
     return merge_dicts(results, policy=merge_policy)
 
 
 def strategy_concat(
-    results: list[Any],
+    results: Iterable[Any],
     separator: str = "\n\n",
     **kwargs,
 ) -> str:
-    """Concat strategy: append all outputs sequentially."""
+    """Concat strategy: append all outputs sequentially. Accepts list or iterator."""
     text_results = []
     for r in results:
         if isinstance(r, str):
@@ -221,54 +288,109 @@ STRATEGIES: dict[str, Callable] = {
 }
 
 
-def _rollup_metrics(results: list[Any]) -> dict:
-    """Sum metrics.* fields across result envelopes (P1-C).
+class _IncrementalRollup:
+    """Accumulator for cost/perf metrics observed one envelope at a time.
 
-    Only operates on entries that look like the v1 envelope
-    (dict with a ``metrics`` sub-dict). Returns totals plus a per-model
-    breakdown when ``metrics.model`` is present.
+    Enables the streaming aggregation pipeline (phase 7 P1-A) to compute the
+    same rollup that `_rollup_metrics` used to derive from a fully materialized
+    list, without requiring the corpus to be held in memory simultaneously.
     """
-    total_tokens = 0
-    total_cost = 0.0
-    total_duration = 0.0
-    per_model: dict[str, dict] = {}
-    saw_any = False
-    for r in results:
+
+    __slots__ = (
+        "total_tokens",
+        "total_cost",
+        "total_duration",
+        "per_model",
+        "saw_any",
+    )
+
+    def __init__(self) -> None:
+        self.total_tokens = 0
+        self.total_cost = 0.0
+        self.total_duration = 0.0
+        self.per_model: dict[str, dict] = {}
+        self.saw_any = False
+
+    def observe(self, r: Any) -> None:
         if not isinstance(r, dict):
-            continue
+            return
         m = r.get("metrics")
         if not isinstance(m, dict):
-            continue
-        saw_any = True
+            return
+        self.saw_any = True
         tokens = m.get("tokens_used")
         cost = m.get("cost_usd")
         dur = m.get("duration_seconds")
         model = m.get("model")
         if isinstance(tokens, (int, float)):
-            total_tokens += int(tokens)
+            self.total_tokens += int(tokens)
         if isinstance(cost, (int, float)):
-            total_cost += float(cost)
+            self.total_cost += float(cost)
         if isinstance(dur, (int, float)):
-            total_duration += float(dur)
+            self.total_duration += float(dur)
         if isinstance(model, str):
-            bucket = per_model.setdefault(model, {"count": 0, "tokens_used": 0, "cost_usd": 0.0})
+            bucket = self.per_model.setdefault(
+                model, {"count": 0, "tokens_used": 0, "cost_usd": 0.0}
+            )
             bucket["count"] += 1
             if isinstance(tokens, (int, float)):
                 bucket["tokens_used"] += int(tokens)
             if isinstance(cost, (int, float)):
                 bucket["cost_usd"] += float(cost)
-    if not saw_any:
-        return {}
-    result: dict = {}
-    if total_tokens:
-        result["total_tokens"] = total_tokens
-    if total_cost:
-        result["total_cost_usd"] = round(total_cost, 6)
-    if total_duration:
-        result["total_duration_seconds"] = round(total_duration, 3)
-    if per_model:
-        result["per_model"] = per_model
-    return result
+
+    def result(self) -> dict:
+        if not self.saw_any:
+            return {}
+        out: dict = {}
+        if self.total_tokens:
+            out["total_tokens"] = self.total_tokens
+        if self.total_cost:
+            out["total_cost_usd"] = round(self.total_cost, 6)
+        if self.total_duration:
+            out["total_duration_seconds"] = round(self.total_duration, 3)
+        if self.per_model:
+            out["per_model"] = self.per_model
+        return out
+
+
+def _rollup_metrics(results: Iterable[Any]) -> dict:
+    """Sum metrics.* fields across result envelopes (P1-C).
+
+    Accepts a list or any iterable. Internally delegates to `_IncrementalRollup`
+    so the same accounting runs in both streaming and materialized paths.
+    """
+    rollup = _IncrementalRollup()
+    for r in results:
+        rollup.observe(r)
+    return rollup.result()
+
+
+def _maybe_spill_data(envelope: dict, path: Path, budget_bytes: int) -> dict:
+    """If ``envelope['data']`` serializes above ``budget_bytes``, replace it with an
+    artifact pointer per references/result-schema.md (non-envelope-outputs).
+
+    Returns the original envelope when under budget or when it has no ``data``
+    field; returns a shallow copy with ``data`` replaced otherwise. The envelope
+    itself is never mutated.
+    """
+    if budget_bytes <= 0 or not isinstance(envelope, dict):
+        return envelope
+    data = envelope.get("data")
+    if data is None:
+        return envelope
+    try:
+        serialized = json.dumps(data, default=str)
+    except (TypeError, ValueError):
+        return envelope
+    size = len(serialized)
+    if size <= budget_bytes:
+        return envelope
+    spilled = dict(envelope)
+    spilled["data"] = {
+        "artifact_path": str(path),
+        "artifact_size": size,
+    }
+    return spilled
 
 
 def main():
@@ -325,6 +447,23 @@ Examples:
         help="Validate each input against references/result-schema.json (v1 envelope). "
              "Drops status=='failed' entries from merge/concat; malformed envelopes abort.",
     )
+    # Streaming aggregation / memory cap (phase 7 P1-A)
+    parser.add_argument(
+        "--max-memory-mb",
+        type=float,
+        default=None,
+        metavar="MB",
+        help="Per-envelope data budget. Envelopes whose `data` serializes above this "
+             "MiB threshold are replaced with {artifact_path, artifact_size} pointers "
+             "(see references/result-schema.md). Omit to retain all payloads.",
+    )
+    parser.add_argument(
+        "--load-workers",
+        type=int,
+        default=8,
+        metavar="N",
+        help="Max concurrent file-load workers for the streaming loader (default: %(default)s).",
+    )
     add_log_format_arg(parser)
 
     args = parser.parse_args()
@@ -350,28 +489,15 @@ Examples:
     
     print(f"Found {len(input_files)} result files", file=sys.stderr)
     
-    # Load results (parallel for large file counts)
-    results: list[Any] = []
+    # Shared accumulators (mutated during streaming load).
     provenance: dict[str, dict] = {}
     failed_files: list[str] = []
-    
-    def load_file(f: Path) -> tuple[Path, Any]:
-        """Load a single file, return (path, data or None)."""
-        if f.suffix == ".json":
-            return f, load_json_file(f)
-        return f, load_text_file(f)
-    
-    # Use threads for I/O-bound file loading when many files
-    if len(input_files) > 10:
-        from concurrent.futures import ThreadPoolExecutor
-        with ThreadPoolExecutor(max_workers=min(8, len(input_files))) as executor:
-            loaded = list(executor.map(load_file, input_files))
-    else:
-        loaded = [load_file(f) for f in input_files]
-    
     status_counts: Counter = Counter()
     schema_errors: list[tuple[str, list[str]]] = []
+    rollup = _IncrementalRollup()
+
     validator_schema = None
+    validate_envelope = None  # bound on demand to keep imports lazy
     if args.validate_schema:
         try:
             from scripts.schema_validator import validate_envelope, _load_schema  # type: ignore
@@ -383,33 +509,89 @@ Examples:
                 from schema_validator import validate_envelope, _load_schema  # type: ignore
         validator_schema = _load_schema()
 
-    for f, data in loaded:
-        if data is None:
-            failed_files.append(str(f))
-            if not args.skip_invalid:
-                print(f"Warning: Failed to load {f}", file=sys.stderr)
-            continue
+    spill_budget_bytes = (
+        int(args.max_memory_mb * 1024 * 1024)
+        if args.max_memory_mb is not None and args.max_memory_mb > 0
+        else 0
+    )
+    # Counter incremented inside the streaming generator so vote/latest paths
+    # (which materialize) and merge/concat paths (which don't) agree on the
+    # number of accepted envelopes without an extra pass.
+    successful_ref = [0]
+    spilled_ref = [0]
 
-        if args.validate_schema and isinstance(data, dict):
-            vr = validate_envelope(data, schema=validator_schema)
-            if not vr.ok:
-                schema_errors.append((str(f), vr.errors))
+    def _envelope_stream() -> Iterator[Any]:
+        """Single-pass loader + validator + rollup observer.
+
+        Yields envelopes that survive: parse success, schema validation (if
+        enabled), and the status != 'failed' filter. Updates the outer
+        accumulators as a side effect so the caller gets stats regardless of
+        whether the strategy consumed lazily or materialized.
+        """
+        for f, data in iter_loaded_files(input_files, max_workers=args.load_workers):
+            if data is None:
                 failed_files.append(str(f))
-                print(f"Schema: {f} ✗ {'; '.join(vr.errors)}", file=sys.stderr)
-                continue
-            status = data.get("status")
-            status_counts[str(status)] += 1
-            # Drop status=='failed' entries from aggregation per migration plan
-            if status == "failed":
+                if not args.skip_invalid:
+                    print(f"Warning: Failed to load {f}", file=sys.stderr)
                 continue
 
-        results.append(data)
-        if args.include_provenance:
-            agent_id = f.parent.name if f.parent != args.input_dir else f.stem
-            provenance[agent_id] = {
-                "file": str(f),
-                "timestamp": datetime.fromtimestamp(f.stat().st_mtime).isoformat(),
-            }
+            if args.validate_schema and isinstance(data, dict):
+                vr = validate_envelope(data, schema=validator_schema)
+                if not vr.ok:
+                    schema_errors.append((str(f), vr.errors))
+                    failed_files.append(str(f))
+                    print(f"Schema: {f} \u2717 {'; '.join(vr.errors)}", file=sys.stderr)
+                    continue
+                status = data.get("status")
+                status_counts[str(status)] += 1
+                if status == "failed":
+                    continue
+
+            if spill_budget_bytes:
+                new_data = _maybe_spill_data(data, f, spill_budget_bytes)
+                if new_data is not data:
+                    spilled_ref[0] += 1
+                    log_event(
+                        "aggregate.spill",
+                        path=str(f),
+                        artifact_size=new_data["data"]["artifact_size"],
+                        budget_bytes=spill_budget_bytes,
+                    )
+                    data = new_data
+
+            rollup.observe(data)
+            successful_ref[0] += 1
+            if args.include_provenance:
+                agent_id = f.parent.name if f.parent != args.input_dir else f.stem
+                provenance[agent_id] = {
+                    "file": str(f),
+                    "timestamp": datetime.fromtimestamp(f.stat().st_mtime).isoformat(),
+                }
+            yield data
+
+    # Run aggregation. merge/concat fold the stream directly; vote/latest need
+    # a list because they traverse results twice (sort / count).
+    start_time = datetime.now()
+    strategy_fn = STRATEGIES[args.strategy]
+    if args.strategy in ("merge", "concat"):
+        aggregated = strategy_fn(
+            _envelope_stream(),
+            merge_policy=args.merge_policy,
+            separator=args.concat_separator,
+        )
+        results_for_output: list[Any] = []  # not referenced below
+    else:
+        results_for_output = list(_envelope_stream())
+        aggregated = strategy_fn(
+            results_for_output,
+            merge_policy=args.merge_policy,
+            separator=args.concat_separator,
+            vote_field=args.vote_field,
+            vote_threshold=args.vote_threshold,
+            weighted=args.vote_weighted,
+            timestamp_field=args.timestamp_field,
+        )
+    end_time = datetime.now()
 
     if args.validate_schema and schema_errors:
         print(
@@ -417,39 +599,23 @@ Examples:
             file=sys.stderr,
         )
         sys.exit(1)
-    
-    # Check success ratio
+
+    # Check success ratio (post-stream, so successful_ref is final).
     total = len(input_files)
-    successful = len(results)
+    successful = successful_ref[0]
     success_ratio = successful / total if total else 0
-    
+
     if args.strict and failed_files:
         print(f"Error: {len(failed_files)} files failed to load (strict mode)", file=sys.stderr)
         sys.exit(1)
-    
+
     if success_ratio < args.min_success:
         print(f"Error: Success ratio {success_ratio:.1%} below minimum {args.min_success:.1%}", file=sys.stderr)
         sys.exit(1)
-    
-    if not results:
+
+    if successful == 0:
         print("Error: No valid results to aggregate", file=sys.stderr)
         sys.exit(1)
-    
-    # Run aggregation
-    start_time = datetime.now()
-    
-    strategy_fn = STRATEGIES[args.strategy]
-    aggregated = strategy_fn(
-        results,
-        merge_policy=args.merge_policy,
-        separator=args.concat_separator,
-        vote_field=args.vote_field,
-        vote_threshold=args.vote_threshold,
-        weighted=args.vote_weighted,
-        timestamp_field=args.timestamp_field,
-    )
-    
-    end_time = datetime.now()
     
     # Build final output
     if args.include_provenance or args.include_stats:
@@ -475,10 +641,12 @@ Examples:
                 output["stats"]["failed_files"] = failed_files
             if args.validate_schema and status_counts:
                 output["stats"]["status_breakdown"] = dict(status_counts)
-            # Cost/perf rollup (P1-C): sum metrics.* across envelope-shaped inputs.
-            cost_rollup = _rollup_metrics(results)
+            # Cost/perf rollup (P1-C): accumulated inline during streaming load.
+            cost_rollup = rollup.result()
             if cost_rollup:
                 output["stats"]["metrics_rollup"] = cost_rollup
+            if spilled_ref[0]:
+                output["stats"]["spilled_payloads"] = spilled_ref[0]
     else:
         output = aggregated
     
@@ -530,6 +698,7 @@ Examples:
         successful=successful,
         failed=len(failed_files),
         success_ratio=success_ratio,
+        spilled=spilled_ref[0],
         output=str(args.output),
     )
 

--- a/scripts/credential_helper.py
+++ b/scripts/credential_helper.py
@@ -31,6 +31,7 @@ Design:
     - Service name defaults to 'multi-agent-workflows' but is configurable
       via --service / MAW_CRED_SERVICE so users can namespace secrets.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -41,7 +42,6 @@ import subprocess
 import sys
 from abc import ABC, abstractmethod
 from typing import Optional
-
 
 DEFAULT_SERVICE = os.environ.get("MAW_CRED_SERVICE", "multi-agent-workflows")
 
@@ -145,17 +145,17 @@ class OnePasswordBackend(CredentialBackend):
                 check=True,
             )
             return out.stdout.rstrip("\n")
-        except FileNotFoundError:
-            raise RuntimeError("`op` CLI not found. Install 1Password CLI: https://developer.1password.com/docs/cli/")
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "`op` CLI not found. Install 1Password CLI: https://developer.1password.com/docs/cli/"
+            ) from exc
         except subprocess.CalledProcessError as e:
             if "isn't an item" in (e.stderr or "") or "not found" in (e.stderr or "").lower():
                 return None
             raise
 
     def set(self, key: str, value: str, service: str = DEFAULT_SERVICE) -> None:
-        raise NotImplementedError(
-            "1Password write is not implemented. Create items manually or use `op item create`."
-        )
+        raise NotImplementedError("1Password write is not implemented. Create items manually or use `op item create`.")
 
 
 class VaultBackend(CredentialBackend):
@@ -248,18 +248,16 @@ class OzSecretBackend(CredentialBackend):
                 check=True,
                 capture_output=True,
             )
-        except FileNotFoundError:
+        except FileNotFoundError as exc:
             raise RuntimeError(
                 "`oz` CLI not found. Install Warp's Oz CLI: https://docs.warp.dev/reference/cli"
-            )
+            ) from exc
         except subprocess.CalledProcessError as e:
             stderr = (e.stderr or "").strip()
             # If secret exists, transparently update.
             if "already exists" in stderr.lower() or "conflict" in stderr.lower():
                 update_cmd = ["oz", "secret", "update", key]
-                subprocess.run(
-                    update_cmd, input=value, text=True, check=True, capture_output=True
-                )
+                subprocess.run(update_cmd, input=value, text=True, check=True, capture_output=True)
                 return
             raise
 
@@ -271,8 +269,8 @@ class OzSecretBackend(CredentialBackend):
                 capture_output=True,
                 text=True,
             )
-        except FileNotFoundError:
-            raise RuntimeError("`oz` CLI not found.")
+        except FileNotFoundError as exc:
+            raise RuntimeError("`oz` CLI not found.") from exc
 
     def list_secrets(self) -> list[str]:
         """Return the names of secrets stored in Oz (value is NOT returned)."""
@@ -283,8 +281,8 @@ class OzSecretBackend(CredentialBackend):
                 text=True,
                 check=True,
             )
-        except FileNotFoundError:
-            raise RuntimeError("`oz` CLI not found.")
+        except FileNotFoundError as exc:
+            raise RuntimeError("`oz` CLI not found.") from exc
         import json as _json
 
         try:

--- a/scripts/dependency_graph.py
+++ b/scripts/dependency_graph.py
@@ -36,6 +36,7 @@ Optimized ordering:
     - Tasks are topologically sorted; within a phase, they're sorted by id
       for deterministic output.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -63,8 +64,10 @@ def load_manifest(path: Path) -> list[Task]:
     if path.suffix in {".yaml", ".yml"}:
         try:
             import yaml
-        except ImportError:
-            raise RuntimeError("YAML support requires `pip install pyyaml`. Convert to JSON or install pyyaml.")
+        except ImportError as exc:
+            raise RuntimeError(
+                "YAML support requires `pip install pyyaml`. Convert to JSON or install pyyaml."
+            ) from exc
         data = yaml.safe_load(text)
     else:
         data = json.loads(text)
@@ -204,7 +207,7 @@ def format_dot(tasks: list[Task], phases: list[list[Task]]) -> str:
         lines.append(f'    label="Phase {i}";')
         lines.append("    style=dashed;")
         for t in phase:
-            label = f'{t.id}\\n{t.prompt[:40]}'
+            label = f"{t.id}\\n{t.prompt[:40]}"
             lines.append(f'    "{t.id}" [label="{label}"];')
         lines.append("  }")
     # Edges

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -20,6 +20,7 @@ from typing import Any, Optional
 @dataclass
 class EvalResult:
     """Result of evaluating a single test case."""
+
     case_id: str
     case_name: str
     passed: bool
@@ -47,7 +48,7 @@ def analyze_prompt_for_decomposition(prompt: str) -> dict[str, Any]:
         "sharding_applicable": False,
         "phased_workflow": False,
     }
-    
+
     # Detect directory/module mentions
     dir_pattern = r"(?:directories?|modules?|folders?):\s*([^.]+)"
     dir_match = re.search(dir_pattern, prompt, re.IGNORECASE)
@@ -59,32 +60,37 @@ def analyze_prompt_for_decomposition(prompt: str) -> dict[str, Any]:
         analysis["subtask_count"] = len(items)
         analysis["subtask_hints"] = items
         analysis["parallel_potential"] = len(items) > 1
-    
+
     # Detect sharding keywords
     if any(kw in prompt.lower() for kw in ["split", "shard", "divide", "parallel agents"]):
         analysis["sharding_applicable"] = True
-    
+
     # Detect file count mentions
     file_count_match = re.search(r"(\d+)\s*(?:test\s+)?files?", prompt)
     if file_count_match:
         analysis["file_count"] = int(file_count_match.group(1))
         analysis["sharding_applicable"] = True
-    
+
     # Detect version/environment enumeration (e.g., "Python 3.9, 3.10, 3.11, and 3.12")
     version_matches = re.findall(r"\d+\.\d+", prompt)
     if len(version_matches) >= 2:
         analysis["subtask_count"] = max(analysis["subtask_count"], len(version_matches))
         analysis["parallel_potential"] = True
         analysis["version_enumeration"] = version_matches
-    
+
     # Detect phased workflows (use word boundaries to avoid false matches)
     phase_keywords = [
-        r"\bfirst\b", r"\bthen\b", r"\bonce\b", r"\bafter\b",
-        r"\bbefore\b", r"\bphase\b", r"\bsynthesis\b",
+        r"\bfirst\b",
+        r"\bthen\b",
+        r"\bonce\b",
+        r"\bafter\b",
+        r"\bbefore\b",
+        r"\bphase\b",
+        r"\bsynthesis\b",
     ]
     if any(re.search(kw, prompt.lower()) for kw in phase_keywords):
         analysis["phased_workflow"] = True
-    
+
     # Detect backend hints
     if "k8s" in prompt.lower() or "kubernetes" in prompt.lower():
         analysis["suggested_backend"] = "k8s"
@@ -92,22 +98,22 @@ def analyze_prompt_for_decomposition(prompt: str) -> dict[str, Any]:
         analysis["suggested_backend"] = "ci"
     elif "ssh" in prompt.lower() or "remote" in prompt.lower():
         analysis["suggested_backend"] = "remote"
-    
+
     # Detect agent count
     agent_match = re.search(r"(\d+)\s*(?:parallel\s+)?agents?", prompt)
     if agent_match:
         analysis["explicit_agent_count"] = int(agent_match.group(1))
-    
+
     return analysis
 
 
 def validate_decomposition(analysis: dict, expected: list[str]) -> tuple[bool, list[str]]:
     """Validate that analysis matches expected decomposition criteria."""
     errors = []
-    
+
     for criterion in expected:
         criterion_lower = criterion.lower()
-        
+
         # Check subtask count
         if "decomposes" in criterion_lower or "subtask" in criterion_lower:
             count_match = re.search(r"(\d+)", criterion)
@@ -115,8 +121,10 @@ def validate_decomposition(analysis: dict, expected: list[str]) -> tuple[bool, l
                 expected_count = int(count_match.group(1))
                 if analysis.get("subtask_count", 0) < expected_count:
                     if not analysis.get("parallel_potential"):
-                        errors.append(f"Expected {expected_count} subtasks, analysis found {analysis.get('subtask_count', 0)}")
-        
+                        errors.append(
+                            f"Expected {expected_count} subtasks, analysis found {analysis.get('subtask_count', 0)}"
+                        )
+
         # Check backend selection (word-boundary matching)
         if re.search(r"\bkubernetes\b|\bk8s\b", criterion_lower):
             if analysis.get("suggested_backend") != "k8s":
@@ -124,12 +132,12 @@ def validate_decomposition(analysis: dict, expected: list[str]) -> tuple[bool, l
         elif re.search(r"\bci\b|\bgithub actions\b", criterion_lower):
             if analysis.get("suggested_backend") != "ci":
                 errors.append(f"Expected CI backend, got {analysis.get('suggested_backend')}")
-        
+
         # Check phased workflow detection (word-boundary)
         if re.search(r"\bphase\b|\bdependency\b|\bdepends on\b|\bsynthesis\b", criterion_lower):
             if not analysis.get("phased_workflow"):
                 errors.append("Expected phased workflow detection")
-    
+
     return len(errors) == 0, errors
 
 
@@ -139,20 +147,20 @@ def evaluate_case_dry_run(case: dict, analysis: dict) -> EvalResult:
     case_name = case["name"]
     criteria = case.get("evaluation_criteria", {})
     expected = case.get("expected_behavior", [])
-    
+
     result = EvalResult(
         case_id=case_id,
         case_name=case_name,
         passed=True,
         score=0.0,
     )
-    
+
     # Validate decomposition
     decomp_valid, decomp_errors = validate_decomposition(analysis, expected)
     result.criteria_results["decomposition_correct"] = decomp_valid
     if not decomp_valid:
         result.errors.extend(decomp_errors)
-    
+
     # Check backend selection
     backend_criterion = criteria.get("backend_selection", "")
     if "docker" in backend_criterion.lower():
@@ -163,22 +171,22 @@ def evaluate_case_dry_run(case: dict, analysis: dict) -> EvalResult:
         result.criteria_results["backend_selection"] = analysis.get("suggested_backend") == "ci"
     else:
         result.criteria_results["backend_selection"] = True  # Default pass
-    
+
     # Check sharding if applicable (use tag-based check, not substring)
     case_tags = case.get("tags", [])
     if "sharding" in case_tags:
         result.criteria_results["sharding_strategy"] = analysis.get("sharding_applicable", False)
-    
+
     # Check phased workflow if applicable (use tag-based check)
     if "phased-execution" in case_tags or "dependencies" in case_tags or "fan-out-fan-in" in case_tags:
         result.criteria_results["phases_identified"] = analysis.get("phased_workflow", False)
-    
+
     # Calculate score
     passed_criteria = sum(1 for v in result.criteria_results.values() if v)
     total_criteria = len(result.criteria_results)
     result.score = passed_criteria / total_criteria if total_criteria > 0 else 0.0
     result.passed = result.score >= 0.8  # 80% threshold from evals.json
-    
+
     return result
 
 
@@ -186,16 +194,16 @@ def run_dry_run_eval(evals_data: dict, case_filter: Optional[str] = None) -> lis
     """Run all evaluations in dry-run mode."""
     results = []
     test_cases = evals_data.get("test_cases", [])
-    
+
     for case in test_cases:
         if case_filter and case["id"] != case_filter:
             continue
-        
+
         prompt = case.get("prompt", "")
         analysis = analyze_prompt_for_decomposition(prompt)
         result = evaluate_case_dry_run(case, analysis)
         results.append(result)
-    
+
     return results
 
 
@@ -203,30 +211,30 @@ def print_results(results: list[EvalResult], verbose: bool = False) -> int:
     """Print evaluation results and return exit code."""
     total = len(results)
     num_passed = sum(1 for r in results if r.passed)
-    
+
     print(f"\n{'='*60}")
     print("Multi-Agent Workflows Eval Results")
     print(f"{'='*60}\n")
-    
+
     for result in results:
         status = "✓ PASS" if result.passed else "✗ FAIL"
         print(f"{status} [{result.case_id}] {result.case_name}")
         print(f"     Score: {result.score:.1%}")
-        
+
         if verbose or not result.passed:
             for criterion, criterion_passed in result.criteria_results.items():
                 mark = "✓" if criterion_passed else "✗"
                 print(f"     {mark} {criterion}")
-            
+
             for error in result.errors:
                 print(f"     ⚠ {error}")
-        
+
         print()
-    
+
     print(f"{'='*60}")
     print(f"Total: {num_passed}/{total} passed ({num_passed/total*100:.0f}%)")
     print(f"{'='*60}")
-    
+
     return 0 if num_passed == total else 1
 
 
@@ -235,19 +243,22 @@ def main():
         description="Run multi-agent-workflows evaluations",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    
+
     parser.add_argument(
-        "--dry-run", "-d",
+        "--dry-run",
+        "-d",
         action="store_true",
         help="Validate without spawning agents (default mode)",
     )
     parser.add_argument(
-        "--integration", "-i",
+        "--integration",
+        "-i",
         action="store_true",
         help="Run full integration tests (requires Docker)",
     )
     parser.add_argument(
-        "--case", "-c",
+        "--case",
+        "-c",
         metavar="ID",
         help="Run specific test case by ID",
     )
@@ -258,7 +269,8 @@ def main():
         help="Path to evals.json file",
     )
     parser.add_argument(
-        "--verbose", "-v",
+        "--verbose",
+        "-v",
         action="store_true",
         help="Show detailed output for all cases",
     )
@@ -267,12 +279,12 @@ def main():
         action="store_true",
         help="Output results as JSON",
     )
-    
+
     args = parser.parse_args()
-    
+
     # Load evals
     evals_data = load_evals(args.evals_file)
-    
+
     # Run evaluations
     if args.integration:
         print("Integration mode not yet implemented", file=sys.stderr)
@@ -281,7 +293,7 @@ def main():
     else:
         # Default to dry-run
         results = run_dry_run_eval(evals_data, args.case)
-    
+
     # Output results
     if args.json:
         output = {

--- a/scripts/schema_validator.py
+++ b/scripts/schema_validator.py
@@ -11,6 +11,7 @@ Works with or without the `jsonschema` package installed:
 - Otherwise, a built-in minimal validator checks the envelope's required
   fields and enum values (sufficient for the v1 envelope; falls back gracefully).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -42,8 +43,7 @@ class ValidationResult:
 def _load_schema() -> dict:
     if not _SCHEMA_PATH.exists():
         raise FileNotFoundError(
-            f"Schema not found at {_SCHEMA_PATH}. "
-            "This file ships with the skill; reinstall if missing."
+            f"Schema not found at {_SCHEMA_PATH}. " "This file ships with the skill; reinstall if missing."
         )
     return json.loads(_SCHEMA_PATH.read_text())
 
@@ -63,9 +63,7 @@ def _builtin_validate(obj: Any) -> list[str]:
     if "schema_version" not in obj:
         errors.append("missing required field: schema_version")
     elif obj["schema_version"] != SCHEMA_VERSION_CONST:
-        errors.append(
-            f"schema_version must be '{SCHEMA_VERSION_CONST}', got {obj['schema_version']!r}"
-        )
+        errors.append(f"schema_version must be '{SCHEMA_VERSION_CONST}', got {obj['schema_version']!r}")
     if "status" not in obj:
         errors.append("missing required field: status")
     elif obj["status"] not in VALID_STATUS:

--- a/scripts/spawn_docker.py
+++ b/scripts/spawn_docker.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -33,14 +33,18 @@ except ImportError:
 
 # Structured logging (optional; degrades gracefully if unavailable)
 try:
-    from scripts._log import configure as _log_configure, log_event, add_log_format_arg  # type: ignore
+    from scripts._log import add_log_format_arg, log_event
+    from scripts._log import configure as _log_configure  # type: ignore
 except ImportError:
     try:
-        from ._log import configure as _log_configure, log_event, add_log_format_arg  # type: ignore
+        from ._log import add_log_format_arg, log_event
+        from ._log import configure as _log_configure  # type: ignore
     except ImportError:
+
         def _log_configure(*_a, **_k): ...
         def log_event(*_a, **_k): ...
         def add_log_format_arg(_p): ...
+
 
 # Preflight thresholds
 MIN_FREE_DISK_MB = 500  # warn if output dir has less than this
@@ -50,6 +54,7 @@ DOCKER_DAEMON_TIMEOUT_SEC = 5
 @dataclass
 class AgentResult:
     """Result of spawning or completing an agent container."""
+
     task_id: str
     task: str
     container_id: str
@@ -59,7 +64,7 @@ class AgentResult:
     retries: int = 0
     start_time: Optional[float] = None
     end_time: Optional[float] = None
-    
+
     @property
     def duration_seconds(self) -> Optional[float]:
         """Calculate task duration if both times are set."""
@@ -92,49 +97,64 @@ def spawn_container(
     docker_args: Optional[str] = None,
 ) -> AgentResult:
     """Spawn a single Docker container for an agent task."""
-    
+
     # Create output directory for this task
     task_output = output_dir / task_id
     task_output.mkdir(parents=True, exist_ok=True)
-    
+
     # Build docker command
     cmd = [
-        "docker", "run", "-d",
-        "--name", task_id,
-        "-v", f"{workspace}:/workspace",
-        "-v", f"{task_output}:/output",
-        "-w", "/workspace",
-        "-e", f"WARP_API_KEY={api_key}",
-        "-e", f"TASK_ID={task_id}",
-        "-e", "OUTPUT_DIR=/output",
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        task_id,
+        "-v",
+        f"{workspace}:/workspace",
+        "-v",
+        f"{task_output}:/output",
+        "-w",
+        "/workspace",
+        "-e",
+        f"WARP_API_KEY={api_key}",
+        "-e",
+        f"TASK_ID={task_id}",
+        "-e",
+        "OUTPUT_DIR=/output",
     ]
-    
+
     # Add extra environment variables
     for key, value in extra_env.items():
         cmd.extend(["-e", f"{key}={value}"])
-    
+
     # Resource limits
     if memory:
         cmd.extend(["--memory", memory])
     if cpus:
         cmd.extend(["--cpus", cpus])
-    
+
     # Network
     if network:
         cmd.extend(["--network", network])
-    
+
     # Extra Docker arguments
     if docker_args:
         cmd.extend(shlex.split(docker_args))
-    
+
     # Image and command
     cmd.append(image)
-    cmd.extend([
-        "oz", "agent", "run",
-        "--prompt", f"{task}. Save results to /output/result.json",
-        "--share", share,
-    ])
-    
+    cmd.extend(
+        [
+            "oz",
+            "agent",
+            "run",
+            "--prompt",
+            f"{task}. Save results to /output/result.json",
+            "--share",
+            share,
+        ]
+    )
+
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
         container_id = result.stdout.strip()
@@ -179,7 +199,7 @@ def wait_for_container(task_id: str, timeout: int = 3600) -> tuple[int, str]:
 
 def calculate_backoff(retry: int, base_delay: float = 2.0, max_delay: float = 60.0) -> float:
     """Calculate exponential backoff delay with jitter."""
-    delay = min(base_delay * (2 ** retry), max_delay)
+    delay = min(base_delay * (2**retry), max_delay)
     jitter = delay * 0.1 * random.random()
     return delay + jitter
 
@@ -214,7 +234,10 @@ def check_disk_space(path: Path, min_free_mb: int = MIN_FREE_DISK_MB) -> tuple[b
         stat = shutil.disk_usage(path)
         free_mb = stat.free // (1024 * 1024)
         if free_mb < min_free_mb:
-            return False, f"Only {free_mb}MB free at {path} (need >= {min_free_mb}MB). Clear disk or choose another --output-dir."
+            return (
+                False,
+                f"Only {free_mb}MB free at {path} (need >= {min_free_mb}MB). Clear disk or choose another --output-dir.",
+            )
         return True, f"{free_mb}MB free at {path}"
     except OSError as e:
         if "No space left" in str(e):
@@ -310,38 +333,73 @@ Examples:
   %(prog)s --tasks "Run linter" --docker-args "--gpus all" --memory 8g
 """,
     )
-    
+
     # Task input (mutually exclusive)
     task_group = parser.add_argument_group("Task Input (one required)")
     task_group.add_argument("--tasks", nargs="+", metavar="PROMPT", help="Task prompts to execute")
-    task_group.add_argument("--tasks-file", type=Path, metavar="FILE", help="File with tasks (one per line, # comments allowed)")
-    
+    task_group.add_argument(
+        "--tasks-file", type=Path, metavar="FILE", help="File with tasks (one per line, # comments allowed)"
+    )
+
     # Container configuration
     container_group = parser.add_argument_group("Container Configuration")
-    container_group.add_argument("--image", default="warpdotdev/dev-base:latest", help="Docker image (default: %(default)s)")
-    container_group.add_argument("--workspace", type=Path, default=Path.cwd(), metavar="DIR", help="Workspace directory to mount")
-    container_group.add_argument("--output-dir", type=Path, default=Path("./outputs"), metavar="DIR", help="Output directory (default: %(default)s)")
+    container_group.add_argument(
+        "--image", default="warpdotdev/dev-base:latest", help="Docker image (default: %(default)s)"
+    )
+    container_group.add_argument(
+        "--workspace", type=Path, default=Path.cwd(), metavar="DIR", help="Workspace directory to mount"
+    )
+    container_group.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("./outputs"),
+        metavar="DIR",
+        help="Output directory (default: %(default)s)",
+    )
     container_group.add_argument("--memory", default="4g", help="Memory limit per container (default: %(default)s)")
     container_group.add_argument("--cpus", default="2", help="CPU limit per container (default: %(default)s)")
     container_group.add_argument("--network", metavar="NAME", help="Docker network name")
     container_group.add_argument("--docker-args", metavar="ARGS", help="Extra Docker run arguments (quoted string)")
     container_group.add_argument("--env", nargs="+", metavar="KEY=VALUE", help="Extra environment variables")
-    
+
     # Execution control
     exec_group = parser.add_argument_group("Execution Control")
-    exec_group.add_argument("--parallel", type=int, default=4, metavar="N", help="Max parallel containers (default: %(default)s)")
-    exec_group.add_argument("--timeout", type=int, default=3600, metavar="SEC", help="Timeout per task in seconds (default: %(default)s)")
+    exec_group.add_argument(
+        "--parallel", type=int, default=4, metavar="N", help="Max parallel containers (default: %(default)s)"
+    )
+    exec_group.add_argument(
+        "--timeout", type=int, default=3600, metavar="SEC", help="Timeout per task in seconds (default: %(default)s)"
+    )
     exec_group.add_argument("--phase", metavar="ID", help="Phase identifier for multi-phase workflows")
-    exec_group.add_argument("--share", default="team", choices=["team", "public", "private"], help="Session sharing mode (default: %(default)s)")
-    
+    exec_group.add_argument(
+        "--share",
+        default="team",
+        choices=["team", "public", "private"],
+        help="Session sharing mode (default: %(default)s)",
+    )
+
     # Fault tolerance
     fault_group = parser.add_argument_group("Fault Tolerance")
-    fault_group.add_argument("--circuit-breaker", type=float, default=0.5, metavar="RATIO", help="Stop if failure rate exceeds threshold (default: %(default)s)")
+    fault_group.add_argument(
+        "--circuit-breaker",
+        type=float,
+        default=0.5,
+        metavar="RATIO",
+        help="Stop if failure rate exceeds threshold (default: %(default)s)",
+    )
     fault_group.add_argument("--retry-failed", action="store_true", help="Retry failed tasks with exponential backoff")
-    fault_group.add_argument("--max-retries", type=int, default=3, metavar="N", help="Max retries per task (default: %(default)s)")
-    fault_group.add_argument("--skip-preflight", action="store_true", help="Skip docker/disk preflight checks (not recommended)")
-    fault_group.add_argument("--credential-backend", choices=["env", "keychain", "1password", "vault", "aws", "oz"], help="Backend for resolving WARP_API_KEY (default: env then keychain; use `env` inside Oz cloud agents)")
-    
+    fault_group.add_argument(
+        "--max-retries", type=int, default=3, metavar="N", help="Max retries per task (default: %(default)s)"
+    )
+    fault_group.add_argument(
+        "--skip-preflight", action="store_true", help="Skip docker/disk preflight checks (not recommended)"
+    )
+    fault_group.add_argument(
+        "--credential-backend",
+        choices=["env", "keychain", "1password", "vault", "aws", "oz"],
+        help="Backend for resolving WARP_API_KEY (default: env then keychain; use `env` inside Oz cloud agents)",
+    )
+
     # Output options
     out_group = parser.add_argument_group("Output")
     out_group.add_argument("--wait", action="store_true", help="Wait for all containers to complete")
@@ -353,7 +411,7 @@ Examples:
         format=getattr(args, "log_format", "text"),
         flush_each=getattr(args, "log_flush_each", False),
     )
-    
+
     # Get API key via credential helper (with env fallback)
     api_key: Optional[str] = None
     if resolve_secret is not None:
@@ -372,7 +430,7 @@ Examples:
             file=sys.stderr,
         )
         sys.exit(1)
-    
+
     # Preflight checks (docker daemon, disk space, output writable)
     preflight_errors = preflight_checks(args.output_dir.resolve(), skip_docker=args.skip_preflight)
     if preflight_errors:
@@ -381,7 +439,7 @@ Examples:
             print(f"  - {e}", file=sys.stderr)
         print("\nRun with --skip-preflight to bypass (not recommended).", file=sys.stderr)
         sys.exit(1)
-    
+
     # Get tasks
     if args.tasks:
         tasks = args.tasks
@@ -389,26 +447,27 @@ Examples:
         tasks = validate_tasks_file(args.tasks_file)
     else:
         parser.error("Must provide --tasks or --tasks-file")
-    
+
     # Parse extra environment variables
     extra_env = {}
     if args.env:
         for env in args.env:
             key, value = env.split("=", 1)
             extra_env[key] = value
-    
+
     # Create output directory
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Spawn containers
     results: list[AgentResult] = []
-    
+
     print(f"Spawning {len(tasks)} agents...", file=sys.stderr)
     log_event("spawn.start", backend="docker", tasks=len(tasks), phase=args.phase, parallel=args.parallel)
     spawn_start = time.time()
 
     # P1-C: O(1) circuit breaker via running counters instead of list rescan.
     from scripts._common import check_circuit_breaker_counters as _cb_counters
+
     cb_failed = 0
     cb_total = 0
 
@@ -419,9 +478,14 @@ Examples:
             # Check circuit breaker (O(1))
             if _cb_counters(cb_failed, cb_total, args.circuit_breaker):
                 print(f"Circuit breaker triggered at {args.circuit_breaker*100}% failure rate", file=sys.stderr)
-                log_event("spawn.circuit_breaker.tripped", backend="docker", threshold=args.circuit_breaker, completed=cb_total)
+                log_event(
+                    "spawn.circuit_breaker.tripped",
+                    backend="docker",
+                    threshold=args.circuit_breaker,
+                    completed=cb_total,
+                )
                 break
-            
+
             task_id = generate_task_id(task, i, args.phase)
             future = executor.submit(
                 spawn_container,
@@ -439,7 +503,7 @@ Examples:
                 docker_args=args.docker_args,
             )
             futures[future] = (task, task_id)
-        
+
         for future in as_completed(futures):
             task, task_id = futures[future]
             result = future.result()
@@ -450,42 +514,61 @@ Examples:
 
             if result.status == "running":
                 print(f"✓ Started: {task_id} ({task[:50]}...)", file=sys.stderr)
-                log_event("spawn.container.started", backend="docker", task_id=task_id, container_id=result.container_id)
+                log_event(
+                    "spawn.container.started", backend="docker", task_id=task_id, container_id=result.container_id
+                )
             else:
                 print(f"✗ Failed to start: {task_id} - {result.error}", file=sys.stderr)
-                log_event("spawn.container.started", backend="docker", task_id=task_id, status="failed", error=result.error)
-    
+                log_event(
+                    "spawn.container.started", backend="docker", task_id=task_id, status="failed", error=result.error
+                )
+
     # Wait for completion if requested
     if args.wait:
         print("\nWaiting for containers to complete...", file=sys.stderr)
-        
+
         for result in results:
             if result.status == "running":
                 result.start_time = time.time()
                 exit_code, error = wait_for_container(result.task_id, args.timeout)
                 result.end_time = time.time()
                 result.exit_code = exit_code
-                
+
                 if exit_code == 0:
                     result.status = "completed"
                     print(f"✓ Completed: {result.task_id} ({result.duration_seconds:.1f}s)", file=sys.stderr)
-                    log_event("spawn.container.completed", backend="docker", task_id=result.task_id, status="completed", duration=result.duration_seconds)
+                    log_event(
+                        "spawn.container.completed",
+                        backend="docker",
+                        task_id=result.task_id,
+                        status="completed",
+                        duration=result.duration_seconds,
+                    )
                 else:
                     result.status = "failed"
                     result.error = error or f"Exit code: {exit_code}"
                     print(f"✗ Failed: {result.task_id} - {result.error}", file=sys.stderr)
-                    log_event("spawn.container.completed", backend="docker", task_id=result.task_id, status="failed", exit_code=exit_code, error=result.error)
-                    
+                    log_event(
+                        "spawn.container.completed",
+                        backend="docker",
+                        task_id=result.task_id,
+                        status="failed",
+                        exit_code=exit_code,
+                        error=result.error,
+                    )
+
                     # Retry logic with exponential backoff
                     if args.retry_failed:
                         for retry in range(args.max_retries):
                             backoff = calculate_backoff(retry)
-                            print(f"  Retrying ({retry + 1}/{args.max_retries}) after {backoff:.1f}s...", file=sys.stderr)
+                            print(
+                                f"  Retrying ({retry + 1}/{args.max_retries}) after {backoff:.1f}s...", file=sys.stderr
+                            )
                             time.sleep(backoff)
-                            
+
                             # Remove failed container
                             subprocess.run(["docker", "rm", "-f", result.task_id], capture_output=True)
-                            
+
                             # Respawn
                             new_result = spawn_container(
                                 task=result.task,
@@ -500,19 +583,19 @@ Examples:
                                 share=args.share,
                                 extra_env=extra_env,
                             )
-                            
+
                             if new_result.status == "running":
                                 exit_code, error = wait_for_container(new_result.task_id, args.timeout)
                                 if exit_code == 0:
                                     result.status = "completed"
                                     result.task_id = new_result.task_id
                                     result.retries = retry + 1
-                                    print(f"  ✓ Retry succeeded", file=sys.stderr)
+                                    print("  ✓ Retry succeeded", file=sys.stderr)
                                     break
-    
+
     # Output results
     spawn_duration = time.time() - spawn_start
-    
+
     if args.json:
         completed_durations = [r.duration_seconds for r in results if r.duration_seconds]
         output = {
@@ -523,7 +606,9 @@ Examples:
             "total_retries": sum(r.retries for r in results),
             "metrics": {
                 "spawn_duration_seconds": spawn_duration,
-                "avg_task_duration_seconds": sum(completed_durations) / len(completed_durations) if completed_durations else None,
+                "avg_task_duration_seconds": (
+                    sum(completed_durations) / len(completed_durations) if completed_durations else None
+                ),
                 "max_task_duration_seconds": max(completed_durations) if completed_durations else None,
             },
             "results": [
@@ -542,12 +627,12 @@ Examples:
         }
         print(json.dumps(output, indent=2))
     else:
-        print(f"\nSummary:", file=sys.stderr)
+        print("\nSummary:", file=sys.stderr)
         print(f"  Total: {len(results)}", file=sys.stderr)
         print(f"  Running: {sum(1 for r in results if r.status == 'running')}", file=sys.stderr)
         print(f"  Completed: {sum(1 for r in results if r.status == 'completed')}", file=sys.stderr)
         print(f"  Failed: {sum(1 for r in results if r.status == 'failed')}", file=sys.stderr)
-        
+
         # Print container IDs for monitoring
         if not args.wait:
             print("\nContainer IDs:", file=sys.stderr)

--- a/scripts/spawn_k8s.py
+++ b/scripts/spawn_k8s.py
@@ -9,22 +9,25 @@ Usage:
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 import time
-import yaml
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+import yaml
+
 # Structured logging (optional; degrades gracefully if unavailable)
 try:
-    from scripts._log import configure as _log_configure, log_event, add_log_format_arg  # type: ignore
+    from scripts._log import add_log_format_arg, log_event
+    from scripts._log import configure as _log_configure  # type: ignore
 except ImportError:
     try:
-        from ._log import configure as _log_configure, log_event, add_log_format_arg  # type: ignore
+        from ._log import add_log_format_arg, log_event
+        from ._log import configure as _log_configure  # type: ignore
     except ImportError:
+
         def _log_configure(*_a, **_k): ...
         def log_event(*_a, **_k): ...
         def add_log_format_arg(_p): ...
@@ -62,30 +65,38 @@ def create_job_manifest(
     share: str,
 ) -> dict:
     """Create a Kubernetes Job manifest."""
-    
+
     volumes = []
     volume_mounts = []
-    
+
     if pvc_name:
-        volumes.append({
-            "name": "workspace",
-            "persistentVolumeClaim": {"claimName": pvc_name},
-        })
-        volume_mounts.append({
-            "name": "workspace",
-            "mountPath": "/workspace",
-        })
-    
+        volumes.append(
+            {
+                "name": "workspace",
+                "persistentVolumeClaim": {"claimName": pvc_name},
+            }
+        )
+        volume_mounts.append(
+            {
+                "name": "workspace",
+                "mountPath": "/workspace",
+            }
+        )
+
     # Output volume (emptyDir)
-    volumes.append({
-        "name": "output",
-        "emptyDir": {},
-    })
-    volume_mounts.append({
-        "name": "output",
-        "mountPath": "/output",
-    })
-    
+    volumes.append(
+        {
+            "name": "output",
+            "emptyDir": {},
+        }
+    )
+    volume_mounts.append(
+        {
+            "name": "output",
+            "mountPath": "/output",
+        }
+    )
+
     manifest = {
         "apiVersion": "batch/v1",
         "kind": "Job",
@@ -109,52 +120,56 @@ def create_job_manifest(
                 },
                 "spec": {
                     "restartPolicy": "Never",
-                    "containers": [{
-                        "name": "agent",
-                        "image": image,
-                        "workingDir": "/workspace" if pvc_name else "/tmp",
-                        "command": ["oz", "agent", "run"],
-                        "args": [
-                            "--prompt", f"{task}. Save results to /output/result.json",
-                            "--share", share,
-                        ],
-                        "env": [
-                            {
-                                "name": "WARP_API_KEY",
-                                "valueFrom": {
-                                    "secretKeyRef": {
-                                        "name": secret_name,
-                                        "key": "WARP_API_KEY",
+                    "containers": [
+                        {
+                            "name": "agent",
+                            "image": image,
+                            "workingDir": "/workspace" if pvc_name else "/tmp",
+                            "command": ["oz", "agent", "run"],
+                            "args": [
+                                "--prompt",
+                                f"{task}. Save results to /output/result.json",
+                                "--share",
+                                share,
+                            ],
+                            "env": [
+                                {
+                                    "name": "WARP_API_KEY",
+                                    "valueFrom": {
+                                        "secretKeyRef": {
+                                            "name": secret_name,
+                                            "key": "WARP_API_KEY",
+                                        },
                                     },
                                 },
+                                {
+                                    "name": "TASK_ID",
+                                    "value": job_name,
+                                },
+                                {
+                                    "name": "OUTPUT_DIR",
+                                    "value": "/output",
+                                },
+                            ],
+                            "volumeMounts": volume_mounts,
+                            "resources": {
+                                "requests": {
+                                    "memory": memory_request,
+                                    "cpu": cpu_request,
+                                },
+                                "limits": {
+                                    "memory": memory_limit,
+                                    "cpu": cpu_limit,
+                                },
                             },
-                            {
-                                "name": "TASK_ID",
-                                "value": job_name,
-                            },
-                            {
-                                "name": "OUTPUT_DIR",
-                                "value": "/output",
-                            },
-                        ],
-                        "volumeMounts": volume_mounts,
-                        "resources": {
-                            "requests": {
-                                "memory": memory_request,
-                                "cpu": cpu_request,
-                            },
-                            "limits": {
-                                "memory": memory_limit,
-                                "cpu": cpu_limit,
-                            },
-                        },
-                    }],
+                        }
+                    ],
                     "volumes": volumes,
                 },
             },
         },
     }
-    
+
     return manifest
 
 
@@ -178,16 +193,21 @@ def get_job_status(job_name: str, namespace: str) -> str:
     try:
         result = subprocess.run(
             [
-                "kubectl", "get", "job", job_name,
-                "-n", namespace,
-                "-o", "jsonpath={.status.conditions[?(@.type=='Complete')].status},{.status.conditions[?(@.type=='Failed')].status},{.status.active}",
+                "kubectl",
+                "get",
+                "job",
+                job_name,
+                "-n",
+                namespace,
+                "-o",
+                "jsonpath={.status.conditions[?(@.type=='Complete')].status},{.status.conditions[?(@.type=='Failed')].status},{.status.active}",
             ],
             capture_output=True,
             text=True,
             check=True,
         )
         complete, failed, active = result.stdout.split(",")
-        
+
         if complete == "True":
             return "completed"
         elif failed == "True":
@@ -261,7 +281,7 @@ def main():
         format=getattr(args, "log_format", "text"),
         flush_each=getattr(args, "log_flush_each", False),
     )
-    
+
     # Get tasks
     tasks = []
     if args.tasks:
@@ -271,23 +291,23 @@ def main():
     else:
         print("Error: Must provide --tasks or --tasks-file", file=sys.stderr)
         sys.exit(1)
-    
+
     # Create namespace if it doesn't exist
     if not args.dry_run:
         subprocess.run(
             ["kubectl", "create", "namespace", args.namespace],
             capture_output=True,
         )
-    
+
     # Create and apply jobs
     results: list[JobResult] = []
 
     print(f"Creating {len(tasks)} Kubernetes Jobs...", file=sys.stderr)
     log_event("spawn.start", backend="k8s", tasks=len(tasks), namespace=args.namespace)
-    
+
     for i, task in enumerate(tasks):
         job_name = generate_job_name(task, i)
-        
+
         manifest = create_job_manifest(
             task=task,
             job_name=job_name,
@@ -301,47 +321,55 @@ def main():
             cpu_limit=args.cpu_limit,
             share=args.share,
         )
-        
+
         if args.dry_run:
             print("---")
             print(yaml.dump(manifest))
-            results.append(JobResult(
-                task_id=job_name,
-                task=task,
-                job_name=job_name,
-                status="dry-run",
-            ))
+            results.append(
+                JobResult(
+                    task_id=job_name,
+                    task=task,
+                    job_name=job_name,
+                    status="dry-run",
+                )
+            )
         else:
             success, output = apply_manifest(manifest)
             if success:
                 print(f"✓ Created: {job_name} ({task[:50]}...)", file=sys.stderr)
                 log_event("spawn.container.started", backend="k8s", task_id=job_name, namespace=args.namespace)
-                results.append(JobResult(
-                    task_id=job_name,
-                    task=task,
-                    job_name=job_name,
-                    status="pending",
-                ))
+                results.append(
+                    JobResult(
+                        task_id=job_name,
+                        task=task,
+                        job_name=job_name,
+                        status="pending",
+                    )
+                )
             else:
                 print(f"✗ Failed to create: {job_name} - {output}", file=sys.stderr)
-                log_event("spawn.container.started", backend="k8s", task_id=job_name, status="failed", error=output[:200])
-                results.append(JobResult(
-                    task_id=job_name,
-                    task=task,
-                    job_name=job_name,
-                    status="failed",
-                    error=output,
-                ))
-    
+                log_event(
+                    "spawn.container.started", backend="k8s", task_id=job_name, status="failed", error=output[:200]
+                )
+                results.append(
+                    JobResult(
+                        task_id=job_name,
+                        task=task,
+                        job_name=job_name,
+                        status="failed",
+                        error=output,
+                    )
+                )
+
     # Wait for completion if requested
     if args.wait and not args.dry_run:
         print("\nWaiting for jobs to complete...", file=sys.stderr)
-        
+
         for result in results:
             if result.status == "pending":
                 status = wait_for_job(result.job_name, args.namespace, args.timeout)
                 result.status = status
-                
+
                 if status == "completed":
                     print(f"✓ Completed: {result.job_name}", file=sys.stderr)
                     log_event("spawn.container.completed", backend="k8s", task_id=result.job_name, status="completed")
@@ -351,7 +379,7 @@ def main():
                 else:
                     print(f"✗ Failed: {result.job_name}", file=sys.stderr)
                     log_event("spawn.container.completed", backend="k8s", task_id=result.job_name, status="failed")
-    
+
     # Output results
     if args.json:
         output = {
@@ -374,14 +402,14 @@ def main():
         }
         print(json.dumps(output, indent=2))
     elif not args.dry_run:
-        print(f"\nSummary:", file=sys.stderr)
+        print("\nSummary:", file=sys.stderr)
         print(f"  Namespace: {args.namespace}", file=sys.stderr)
         print(f"  Total: {len(results)}", file=sys.stderr)
         print(f"  Pending: {sum(1 for r in results if r.status == 'pending')}", file=sys.stderr)
         print(f"  Running: {sum(1 for r in results if r.status == 'running')}", file=sys.stderr)
         print(f"  Completed: {sum(1 for r in results if r.status == 'completed')}", file=sys.stderr)
         print(f"  Failed: {sum(1 for r in results if r.status == 'failed')}", file=sys.stderr)
-        
+
         print("\nMonitor with:", file=sys.stderr)
         print(f"  kubectl get jobs -n {args.namespace} -l app=warp-agent -w", file=sys.stderr)
 

--- a/scripts/spawn_oz.py
+++ b/scripts/spawn_oz.py
@@ -21,6 +21,7 @@ Design notes:
       returns immediately after launching all runs (fire-and-forget, useful
       for scheduled workflows).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -37,14 +38,14 @@ from typing import Optional
 
 # Shared helpers
 try:
-    from scripts._common import calculate_backoff, check_circuit_breaker, validate_tasks_file  # type: ignore
+    from scripts._common import calculate_backoff, validate_tasks_file  # type: ignore
 except ImportError:
     try:
-        from ._common import calculate_backoff, check_circuit_breaker, validate_tasks_file  # type: ignore
+        from ._common import calculate_backoff, validate_tasks_file  # type: ignore
     except ImportError:
         # Fallback: direct script execution without package context
         sys.path.insert(0, str(Path(__file__).parent))
-        from _common import calculate_backoff, check_circuit_breaker, validate_tasks_file  # type: ignore
+        from _common import calculate_backoff, validate_tasks_file  # type: ignore
 
 try:
     from scripts.credential_helper import resolve_secret  # type: ignore
@@ -56,11 +57,14 @@ except ImportError:
 
 # Structured logging (optional; degrades gracefully if unavailable)
 try:
-    from scripts._log import configure as _log_configure, log_event, add_log_format_arg  # type: ignore
+    from scripts._log import add_log_format_arg, log_event
+    from scripts._log import configure as _log_configure  # type: ignore
 except ImportError:
     try:
-        from ._log import configure as _log_configure, log_event, add_log_format_arg  # type: ignore
+        from ._log import add_log_format_arg, log_event
+        from ._log import configure as _log_configure  # type: ignore
     except ImportError:
+
         def _log_configure(*_a, **_k): ...
         def log_event(*_a, **_k): ...
         def add_log_format_arg(_p): ...
@@ -101,8 +105,10 @@ class OzAgentResult:
     def to_envelope(self) -> dict:
         """Emit in the common result envelope (references/result-schema.md)."""
         # Map internal Oz states to envelope-canonical status.
-        status = "ok" if self.status in {"succeeded", "completed"} else (
-            "failed" if self.status in {"failed", "cancelled", "errored"} else "partial"
+        status = (
+            "ok"
+            if self.status in {"succeeded", "completed"}
+            else ("failed" if self.status in {"failed", "cancelled", "errored"} else "partial")
         )
         env: dict = {
             "schema_version": "1",
@@ -141,16 +147,8 @@ def _extract_metrics_from_oz(payload: dict) -> dict:
     out: dict = {}
     nested = payload.get("usage") or payload.get("metrics")
     if isinstance(nested, dict) and nested:
-        tokens = (
-            nested.get("tokens_used")
-            or nested.get("total_tokens")
-            or nested.get("tokens")
-        )
-        cost = (
-            nested.get("cost_usd")
-            or nested.get("cost")
-            or nested.get("total_cost_usd")
-        )
+        tokens = nested.get("tokens_used") or nested.get("total_tokens") or nested.get("tokens")
+        cost = nested.get("cost_usd") or nested.get("cost") or nested.get("total_cost_usd")
         model = nested.get("model") or payload.get("model")
         if isinstance(tokens, (int, float)) and not isinstance(tokens, bool):
             out["tokens_used"] = int(tokens)
@@ -193,11 +191,7 @@ def generate_task_id(task: str, index: int, phase: Optional[str] = None) -> str:
 
 def check_oz_available() -> tuple[bool, str]:
     """Preflight: oz CLI installed and WARP_API_KEY reachable."""
-    if not any(
-        os.access(os.path.join(p, "oz"), os.X_OK)
-        for p in os.environ.get("PATH", "").split(os.pathsep)
-        if p
-    ):
+    if not any(os.access(os.path.join(p, "oz"), os.X_OK) for p in os.environ.get("PATH", "").split(os.pathsep) if p):
         return False, "`oz` CLI not found in PATH. Install Warp CLI: https://docs.warp.dev/reference/cli"
     # `oz` returns 0 for help even without auth; real check happens at spawn time.
     try:
@@ -381,16 +375,38 @@ Examples:
 
     # Execution
     exec_group = parser.add_argument_group("Execution Control")
-    exec_group.add_argument("--parallel", type=int, default=4, metavar="N", help="Max parallel spawns (default: %(default)s)")
-    exec_group.add_argument("--timeout", type=int, default=OZ_RUN_GET_MAX_WAIT_SEC, metavar="SEC", help="Per-run wait timeout (default: %(default)s)")
-    exec_group.add_argument("--poll-interval", type=float, default=OZ_RUN_GET_POLL_SEC, metavar="SEC", help="Polling interval when --wait (default: %(default)s)")
+    exec_group.add_argument(
+        "--parallel", type=int, default=4, metavar="N", help="Max parallel spawns (default: %(default)s)"
+    )
+    exec_group.add_argument(
+        "--timeout",
+        type=int,
+        default=OZ_RUN_GET_MAX_WAIT_SEC,
+        metavar="SEC",
+        help="Per-run wait timeout (default: %(default)s)",
+    )
+    exec_group.add_argument(
+        "--poll-interval",
+        type=float,
+        default=OZ_RUN_GET_POLL_SEC,
+        metavar="SEC",
+        help="Polling interval when --wait (default: %(default)s)",
+    )
     exec_group.add_argument("--phase", metavar="ID", help="Phase identifier for multi-phase workflows")
 
     # Fault tolerance
     fault_group = parser.add_argument_group("Fault Tolerance")
-    fault_group.add_argument("--circuit-breaker", type=float, default=0.5, metavar="RATIO", help="Stop spawning if failure rate exceeds threshold (default: %(default)s)")
+    fault_group.add_argument(
+        "--circuit-breaker",
+        type=float,
+        default=0.5,
+        metavar="RATIO",
+        help="Stop spawning if failure rate exceeds threshold (default: %(default)s)",
+    )
     fault_group.add_argument("--retry-failed", action="store_true", help="Retry failed spawns with exponential backoff")
-    fault_group.add_argument("--max-retries", type=int, default=3, metavar="N", help="Max retries per task (default: %(default)s)")
+    fault_group.add_argument(
+        "--max-retries", type=int, default=3, metavar="N", help="Max retries per task (default: %(default)s)"
+    )
     fault_group.add_argument("--skip-preflight", action="store_true", help="Skip `oz --version` preflight")
     fault_group.add_argument(
         "--credential-backend",
@@ -403,7 +419,13 @@ Examples:
     out_group = parser.add_argument_group("Output")
     out_group.add_argument("--wait", action="store_true", help="Wait for all runs to reach terminal state")
     out_group.add_argument("--json", action="store_true", help="Emit results as JSON envelope per task")
-    out_group.add_argument("--output-dir", type=Path, default=Path("./outputs"), metavar="DIR", help="Directory to write per-run result.json (default: %(default)s)")
+    out_group.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("./outputs"),
+        metavar="DIR",
+        help="Directory to write per-run result.json (default: %(default)s)",
+    )
     add_log_format_arg(out_group)
 
     args = parser.parse_args()
@@ -452,10 +474,18 @@ Examples:
 
     results: list[OzAgentResult] = []
     print(f"Spawning {len(tasks)} cloud agents in environment {args.environment}...", file=sys.stderr)
-    log_event("spawn.start", backend="oz", tasks=len(tasks), phase=args.phase, environment=args.environment, parallel=args.parallel)
+    log_event(
+        "spawn.start",
+        backend="oz",
+        tasks=len(tasks),
+        phase=args.phase,
+        environment=args.environment,
+        parallel=args.parallel,
+    )
 
     # P1-C: O(1) circuit breaker via running counters.
     from scripts._common import check_circuit_breaker_counters as _cb_counters
+
     cb_failed = 0
     cb_total = 0
 
@@ -467,7 +497,9 @@ Examples:
                     f"Circuit breaker tripped at {args.circuit_breaker * 100:.0f}% failure rate; halting spawn.",
                     file=sys.stderr,
                 )
-                log_event("spawn.circuit_breaker.tripped", backend="oz", threshold=args.circuit_breaker, completed=cb_total)
+                log_event(
+                    "spawn.circuit_breaker.tripped", backend="oz", threshold=args.circuit_breaker, completed=cb_total
+                )
                 break
             task_id = generate_task_id(task, i, args.phase)
             fut = pool.submit(spawn_oz_agent, task=task, task_id=task_id, environment=args.environment)

--- a/scripts/wait_for_phase.py
+++ b/scripts/wait_for_phase.py
@@ -23,11 +23,14 @@ from typing import Callable, Optional
 
 # Structured logging (optional; degrades gracefully if unavailable)
 try:
-    from scripts._log import configure as _log_configure, log_event, add_log_format_arg  # type: ignore
+    from scripts._log import add_log_format_arg, log_event
+    from scripts._log import configure as _log_configure  # type: ignore
 except ImportError:
     try:
-        from ._log import configure as _log_configure, log_event, add_log_format_arg  # type: ignore
+        from ._log import add_log_format_arg, log_event
+        from ._log import configure as _log_configure  # type: ignore
     except ImportError:
+
         def _log_configure(*_a, **_k): ...
         def log_event(*_a, **_k): ...
         def add_log_format_arg(_p): ...
@@ -73,15 +76,20 @@ def get_docker_status(container_name: str) -> AgentStatus:
     """Get status of a Docker container."""
     try:
         result = subprocess.run(
-            ["docker", "inspect", container_name, "--format", 
-             "{{.State.Status}},{{.State.ExitCode}},{{.State.StartedAt}},{{.State.FinishedAt}}"],
+            [
+                "docker",
+                "inspect",
+                container_name,
+                "--format",
+                "{{.State.Status}},{{.State.ExitCode}},{{.State.StartedAt}},{{.State.FinishedAt}}",
+            ],
             capture_output=True,
             text=True,
             check=True,
         )
         parts = result.stdout.strip().split(",")
         state, exit_code, started, finished = parts[0], int(parts[1]), parts[2], parts[3]
-        
+
         if state == "running":
             status = Status.RUNNING
         elif state == "exited":
@@ -90,15 +98,17 @@ def get_docker_status(container_name: str) -> AgentStatus:
             status = Status.PENDING
         else:
             status = Status.UNKNOWN
-        
+
         return AgentStatus(
             agent_id=container_name,
             status=status,
             exit_code=exit_code if state == "exited" else None,
             start_time=datetime.fromisoformat(started.replace("Z", "+00:00")) if started else None,
-            end_time=datetime.fromisoformat(finished.replace("Z", "+00:00")) if finished and state == "exited" else None,
+            end_time=(
+                datetime.fromisoformat(finished.replace("Z", "+00:00")) if finished and state == "exited" else None
+            ),
         )
-    except Exception as e:
+    except Exception:
         return AgentStatus(agent_id=container_name, status=Status.UNKNOWN)
 
 
@@ -106,7 +116,17 @@ def get_k8s_jobs(phase: str, namespace: str) -> list[str]:
     """Get list of Kubernetes Jobs matching phase."""
     try:
         result = subprocess.run(
-            ["kubectl", "get", "jobs", "-n", namespace, "-l", f"phase={phase}", "-o", "jsonpath={.items[*].metadata.name}"],
+            [
+                "kubectl",
+                "get",
+                "jobs",
+                "-n",
+                namespace,
+                "-l",
+                f"phase={phase}",
+                "-o",
+                "jsonpath={.items[*].metadata.name}",
+            ],
             capture_output=True,
             text=True,
             check=True,
@@ -137,12 +157,11 @@ def get_k8s_status(job_name: str, namespace: str) -> AgentStatus:
             check=True,
         )
         job = json.loads(result.stdout)
-        
-        conditions = job.get("status", {}).get("conditions", [])
+
         active = job.get("status", {}).get("active", 0)
         succeeded = job.get("status", {}).get("succeeded", 0)
         failed = job.get("status", {}).get("failed", 0)
-        
+
         if succeeded > 0:
             status = Status.COMPLETED
         elif failed > 0:
@@ -151,15 +170,15 @@ def get_k8s_status(job_name: str, namespace: str) -> AgentStatus:
             status = Status.RUNNING
         else:
             status = Status.PENDING
-        
+
         start_time = None
         if "startTime" in job.get("status", {}):
             start_time = datetime.fromisoformat(job["status"]["startTime"].replace("Z", "+00:00"))
-        
+
         completion_time = None
         if "completionTime" in job.get("status", {}):
             completion_time = datetime.fromisoformat(job["status"]["completionTime"].replace("Z", "+00:00"))
-        
+
         return AgentStatus(
             agent_id=job_name,
             status=status,
@@ -181,18 +200,18 @@ def wait_for_agents(
     """Wait for all agents to complete."""
     start = time.time()
     final_statuses = {}
-    
+
     while time.time() - start < timeout:
         all_complete = True
         has_failure = False
-        
+
         # Get pending agents for batch status check
         pending = [a for a in agents if a not in final_statuses]
-        
+
         # Batch status checks for efficiency
         for agent in pending:
             status = get_status_fn(agent)
-            
+
             if status.status in (Status.COMPLETED, Status.FAILED):
                 final_statuses[agent] = status
                 if status.status == Status.FAILED:
@@ -202,51 +221,51 @@ def wait_for_agents(
                     print(f"✓ Completed: {agent}", file=sys.stderr)
             else:
                 all_complete = False
-        
+
         if all_complete:
             return list(final_statuses.values()), True
-        
+
         if fail_fast and has_failure:
             # Get final status for remaining agents
             for agent in agents:
                 if agent not in final_statuses:
                     final_statuses[agent] = get_status_fn(agent)
             return list(final_statuses.values()), False
-        
+
         # Show progress
         completed = len(final_statuses)
         print(f"  Progress: {completed}/{len(agents)} ({(time.time() - start):.0f}s)", file=sys.stderr, end="\r")
-        
+
         time.sleep(poll_interval)
-    
+
     # Timeout - get final status for all agents
     for agent in agents:
         if agent not in final_statuses:
             final_statuses[agent] = get_status_fn(agent)
-    
+
     return list(final_statuses.values()), False
 
 
 def main():
     parser = argparse.ArgumentParser(description="Wait for agent phases to complete")
-    
+
     # Phase selection
     parser.add_argument("--phase", required=True, help="Phase identifier to wait for")
     parser.add_argument("--depends-on", help="Previous phase that must complete first")
-    
+
     # Backend options
     parser.add_argument("--backend", "-b", choices=["docker", "k8s"], default="docker", help="Execution backend")
     parser.add_argument("--namespace", "-n", default="warp-agents", help="Kubernetes namespace")
-    
+
     # Wait options
     parser.add_argument("--timeout", "-t", type=int, default=3600, help="Timeout in seconds")
     parser.add_argument("--poll-interval", type=int, default=5, help="Poll interval in seconds")
     parser.add_argument("--fail-fast", action="store_true", help="Exit immediately on first failure")
-    
+
     # Output options
     parser.add_argument("--output", "-o", type=Path, help="Write status report to file")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
-    
+
     # Success criteria
     parser.add_argument("--min-success", type=float, default=1.0, help="Minimum success ratio (0.0-1.0)")
     add_log_format_arg(parser)
@@ -257,56 +276,58 @@ def main():
         flush_each=getattr(args, "log_flush_each", False),
     )
     log_event("phase.wait.start", phase=args.phase, backend=args.backend)
-    
+
     # If depends-on specified, wait for that phase first
     if args.depends_on:
         print(f"Checking dependency: phase {args.depends_on}...", file=sys.stderr)
-        
+
         if args.backend == "docker":
             dep_agents = get_docker_agents(args.depends_on)
             get_status = get_docker_status
         else:
             dep_agents = get_k8s_jobs(args.depends_on, args.namespace)
-            get_status = lambda j: get_k8s_status(j, args.namespace)
-        
+
+            def get_status(j):
+                return get_k8s_status(j, args.namespace)
+
         if dep_agents:
             statuses, success = wait_for_agents(
                 dep_agents, get_status, args.timeout, args.poll_interval, args.fail_fast
             )
-            
+
             completed = sum(1 for s in statuses if s.status == Status.COMPLETED)
             if completed / len(statuses) < args.min_success:
                 print(f"Error: Dependency phase {args.depends_on} did not meet success criteria", file=sys.stderr)
                 sys.exit(1)
-    
+
     # Get agents for this phase
     print(f"Waiting for phase: {args.phase}...", file=sys.stderr)
-    
+
     if args.backend == "docker":
         agents = get_docker_agents(args.phase)
         get_status = get_docker_status
     else:
         agents = get_k8s_jobs(args.phase, args.namespace)
-        get_status = lambda j: get_k8s_status(j, args.namespace)
-    
+
+        def get_status(j):
+            return get_k8s_status(j, args.namespace)
+
     if not agents:
         print(f"Warning: No agents found for phase {args.phase}", file=sys.stderr)
         sys.exit(0)
-    
+
     print(f"Found {len(agents)} agents", file=sys.stderr)
-    
+
     # Wait for completion
-    statuses, success = wait_for_agents(
-        agents, get_status, args.timeout, args.poll_interval, args.fail_fast
-    )
-    
+    statuses, success = wait_for_agents(agents, get_status, args.timeout, args.poll_interval, args.fail_fast)
+
     # Calculate results
     completed = sum(1 for s in statuses if s.status == Status.COMPLETED)
     failed = sum(1 for s in statuses if s.status == Status.FAILED)
     pending = sum(1 for s in statuses if s.status in (Status.PENDING, Status.RUNNING))
     total = len(statuses)
     success_ratio = completed / total if total else 0
-    
+
     # Build report
     report = {
         "phase": args.phase,
@@ -329,7 +350,7 @@ def main():
             for s in statuses
         ],
     }
-    
+
     # Output
     if args.json:
         print(json.dumps(report, indent=2))
@@ -340,20 +361,40 @@ def main():
         print(f"  Failed: {failed}", file=sys.stderr)
         print(f"  Pending: {pending}", file=sys.stderr)
         print(f"  Success ratio: {success_ratio:.1%}", file=sys.stderr)
-    
+
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(json.dumps(report, indent=2))
         print(f"Report written to {args.output}", file=sys.stderr)
-    
+
     # Exit code
     if success_ratio >= args.min_success:
         print(f"✓ Phase {args.phase} completed successfully", file=sys.stderr)
-        log_event("phase.wait.done", phase=args.phase, backend=args.backend, status="ok", completed=completed, failed=failed, total=total, success_ratio=success_ratio)
+        log_event(
+            "phase.wait.done",
+            phase=args.phase,
+            backend=args.backend,
+            status="ok",
+            completed=completed,
+            failed=failed,
+            total=total,
+            success_ratio=success_ratio,
+        )
         sys.exit(0)
     else:
-        print(f"✗ Phase {args.phase} failed (success ratio {success_ratio:.1%} < {args.min_success:.1%})", file=sys.stderr)
-        log_event("phase.wait.done", phase=args.phase, backend=args.backend, status="failed", completed=completed, failed=failed, total=total, success_ratio=success_ratio)
+        print(
+            f"✗ Phase {args.phase} failed (success ratio {success_ratio:.1%} < {args.min_success:.1%})", file=sys.stderr
+        )
+        log_event(
+            "phase.wait.done",
+            phase=args.phase,
+            backend=args.backend,
+            status="failed",
+            completed=completed,
+            failed=failed,
+            total=total,
+            success_ratio=success_ratio,
+        )
         sys.exit(1)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,8 @@
 """Shared pytest fixtures for multi-agent-workflows tests."""
 
 import json
-import os
 import sys
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -44,7 +42,7 @@ def sample_json_results(tmp_outputs):
         {"module": "api", "score": 92, "issues": []},
         {"module": "db", "score": 78, "issues": ["missing indexes"]},
     ]
-    
+
     paths = []
     for i, result in enumerate(results):
         agent_dir = tmp_outputs / f"agent-{i}"
@@ -52,7 +50,7 @@ def sample_json_results(tmp_outputs):
         result_file = agent_dir / "result.json"
         result_file.write_text(json.dumps(result))
         paths.append(result_file)
-    
+
     return paths
 
 
@@ -64,7 +62,7 @@ def sample_vote_results(tmp_outputs):
         {"decision": True, "confidence": 0.92},
         {"decision": False, "confidence": 0.78},
     ]
-    
+
     paths = []
     for i, result in enumerate(results):
         agent_dir = tmp_outputs / f"voter-{i}"
@@ -72,19 +70,20 @@ def sample_vote_results(tmp_outputs):
         result_file = agent_dir / "result.json"
         result_file.write_text(json.dumps(result))
         paths.append(result_file)
-    
+
     return paths
 
 
 @pytest.fixture
 def mock_subprocess_docker_success():
     """Mock subprocess for successful Docker operations."""
+
     def _mock_run(cmd, **kwargs):
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stdout = ""
         mock_result.stderr = ""
-        
+
         if cmd[0] == "docker":
             if cmd[1] == "run":
                 mock_result.stdout = "abc123container456"
@@ -94,25 +93,26 @@ def mock_subprocess_docker_success():
                 mock_result.stdout = "agent-1-task\nagent-2-task"
             elif cmd[1] == "inspect":
                 mock_result.stdout = "exited,0,2024-01-01T10:00:00Z,2024-01-01T10:05:00Z"
-        
+
         return mock_result
-    
+
     return _mock_run
 
 
 @pytest.fixture
 def mock_subprocess_docker_failure():
     """Mock subprocess for failed Docker operations."""
+
     def _mock_run(cmd, **kwargs):
         mock_result = MagicMock()
         mock_result.returncode = 1
         mock_result.stdout = ""
         mock_result.stderr = "Container failed to start"
-        
+
         if cmd[0] == "docker":
             if cmd[1] == "wait":
                 mock_result.stdout = "1"
-        
+
         return mock_result
-    
+
     return _mock_run

--- a/tests/test_aggregate_results.py
+++ b/tests/test_aggregate_results.py
@@ -240,3 +240,171 @@ class TestIntegration:
         # 2 True vs 1 False
         assert voted["decision"] is True
         assert voted["winner_count"] == 2
+
+
+class TestIterLoadedFiles:
+    """Phase 7 P1-A: streaming loader."""
+
+    def _write(self, tmp_path, n, bad_indices=()):
+        files = []
+        for i in range(n):
+            f = tmp_path / f"r{i}.json"
+            if i in bad_indices:
+                f.write_text("not json")
+            else:
+                f.write_text(f'{{"i": {i}}}')
+            files.append(f)
+        return files
+
+    def test_sequential_small_corpus(self, tmp_path):
+        files = self._write(tmp_path, 5)
+        loaded = list(ar.iter_loaded_files(files))
+        assert [d for _, d in loaded] == [{"i": i} for i in range(5)]
+
+    def test_parallel_large_corpus_preserves_order(self, tmp_path):
+        files = self._write(tmp_path, 50)
+        loaded = list(ar.iter_loaded_files(files, max_workers=4))
+        assert [d["i"] for _, d in loaded] == list(range(50))
+
+    def test_lazy_iteration_is_a_generator(self, tmp_path):
+        files = self._write(tmp_path, 20)
+        it = ar.iter_loaded_files(files, max_workers=4)
+        # First value arrives without materializing the whole list.
+        first = next(it)
+        assert first[1]["i"] == 0
+        # Drain the rest to release workers.
+        rest = list(it)
+        assert len(rest) == 19
+
+    def test_parse_failures_yield_none(self, tmp_path):
+        files = self._write(tmp_path, 20, bad_indices={3, 7})
+        loaded = list(ar.iter_loaded_files(files, max_workers=4))
+        nones = [i for i, (_, d) in enumerate(loaded) if d is None]
+        assert nones == [3, 7]
+
+    def test_empty_input(self, tmp_path):
+        assert list(ar.iter_loaded_files([])) == []
+
+
+class TestMergeDictsStreaming:
+    """Phase 7 P1-A: merge_dicts must tolerate iterator input."""
+
+    def test_merge_from_generator_last_policy(self):
+        gen = ({"k": i, f"x{i}": i} for i in range(5))
+        merged = ar.merge_dicts(gen, policy="last")
+        assert merged["k"] == 4
+        assert merged["x0"] == 0 and merged["x4"] == 4
+
+    def test_merge_from_generator_first_policy_matches_list(self):
+        items = [{"k": 1}, {"k": 2, "m": 9}, {"k": 3, "m": 10}]
+        from_list = ar.merge_dicts(list(items), policy="first")
+        from_iter = ar.merge_dicts(iter(items), policy="first")
+        assert from_list == from_iter == {"k": 1, "m": 9}
+
+    def test_merge_from_generator_concat_policy(self):
+        gen = (d for d in [{"xs": [1, 2]}, {"xs": [3, 4]}, {"xs": [5]}])
+        merged = ar.merge_dicts(gen, policy="concat")
+        assert merged == {"xs": [1, 2, 3, 4, 5]}
+
+
+class TestIncrementalRollup:
+    """Phase 7 P1-A: inline metrics rollup must match the list-based form."""
+
+    def _envelopes(self):
+        return [
+            {"status": "ok", "metrics": {"tokens_used": 100, "cost_usd": 0.01, "duration_seconds": 1.0, "model": "claude-opus-4"}},
+            {"status": "ok", "metrics": {"tokens_used": 250, "cost_usd": 0.04, "duration_seconds": 2.5, "model": "gpt-4"}},
+            {"status": "ok", "metrics": {"tokens_used": 50, "cost_usd": 0.005, "duration_seconds": 0.5, "model": "claude-opus-4"}},
+        ]
+
+    def test_incremental_equals_batch(self):
+        envs = self._envelopes()
+        batch = ar._rollup_metrics(envs)
+        incr = ar._IncrementalRollup()
+        for e in envs:
+            incr.observe(e)
+        assert incr.result() == batch
+
+    def test_empty_rollup(self):
+        assert ar._IncrementalRollup().result() == {}
+        assert ar._rollup_metrics([]) == {}
+
+    def test_non_envelope_entries_ignored(self):
+        incr = ar._IncrementalRollup()
+        incr.observe("not a dict")
+        incr.observe({"no": "metrics"})
+        incr.observe({"metrics": "not a dict"})
+        assert incr.result() == {}
+
+
+class TestMaybeSpillData:
+    """Phase 7 P1-A: --max-memory-mb artifact-pointer spillover."""
+
+    def test_below_budget_returns_envelope_unchanged(self, tmp_path):
+        env = {"status": "ok", "data": {"small": "payload"}}
+        result = ar._maybe_spill_data(env, tmp_path / "r.json", budget_bytes=1024)
+        assert result is env  # identity preserved
+
+    def test_above_budget_replaces_data_with_pointer(self, tmp_path):
+        big = "x" * 500
+        env = {"status": "ok", "data": {"payload": big}, "task_id": "t1"}
+        path = tmp_path / "big.json"
+        result = ar._maybe_spill_data(env, path, budget_bytes=100)
+        assert result is not env
+        assert result["data"] == {
+            "artifact_path": str(path),
+            "artifact_size": result["data"]["artifact_size"],
+        }
+        assert result["data"]["artifact_size"] > 100
+        # Original envelope untouched.
+        assert env["data"] == {"payload": big}
+
+    def test_missing_data_field_skipped(self, tmp_path):
+        env = {"status": "ok", "task_id": "t1"}
+        assert ar._maybe_spill_data(env, tmp_path / "r.json", 10) is env
+
+    def test_zero_budget_noop(self, tmp_path):
+        env = {"status": "ok", "data": {"x": "y" * 9999}}
+        assert ar._maybe_spill_data(env, tmp_path / "r.json", 0) is env
+
+
+class TestStreamingMainIntegration:
+    """End-to-end: invoke aggregate_results main() with streaming + spillover."""
+
+    def _write_corpus(self, tmp_path, n=25, big_at=(0, 12)):
+        root = tmp_path / "outputs"
+        root.mkdir()
+        for i in range(n):
+            sub = root / f"agent-{i:03d}"
+            sub.mkdir()
+            data = {"payload": "x" * 600} if i in big_at else {"i": i}
+            env = {
+                "schema_version": "1",
+                "status": "ok",
+                "task_id": f"t{i}",
+                "data": data,
+                "metrics": {"tokens_used": 10 + i, "cost_usd": 0.001 * i, "model": "claude-opus-4"},
+            }
+            (sub / "result.json").write_text(json.dumps(env))
+        return root
+
+    def test_streaming_merge_with_spillover(self, tmp_path, monkeypatch):
+        root = self._write_corpus(tmp_path, n=25, big_at={0, 12})
+        out = tmp_path / "report.json"
+        argv = [
+            "aggregate_results.py",
+            "--input-dir", str(root),
+            "--output", str(out),
+            "--strategy", "merge",
+            "--max-memory-mb", str(100 / (1024 * 1024)),  # 100-byte budget
+            "--include-stats",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        ar.main()
+        report = json.loads(out.read_text())
+        assert report["stats"]["total_files"] == 25
+        assert report["stats"]["successful"] == 25
+        assert report["stats"]["spilled_payloads"] == 2
+        # metrics rollup rolled up inline
+        assert "metrics_rollup" in report["stats"]
+        assert report["stats"]["metrics_rollup"]["total_tokens"] == sum(10 + i for i in range(25))

--- a/tests/test_aggregate_results.py
+++ b/tests/test_aggregate_results.py
@@ -1,11 +1,9 @@
 """Tests for aggregate_results.py."""
 
 import json
-from pathlib import Path
-
-import pytest
 
 import aggregate_results as ar
+import pytest
 
 
 class TestMergeDicts:
@@ -92,7 +90,7 @@ class TestStrategyVote:
         voted = ar.strategy_vote(results, vote_field="decision")
         assert voted["decision"] is True
         assert voted["vote_count"] == {"True": 2, "False": 1}
-        assert voted["winner_ratio"] == pytest.approx(2/3)
+        assert voted["winner_ratio"] == pytest.approx(2 / 3)
 
     def test_majority_false(self):
         results = [
@@ -130,9 +128,7 @@ class TestStrategyVote:
             {"decision": False, "confidence": 0.5},
             {"decision": False, "confidence": 0.5},
         ]
-        voted = ar.strategy_vote(
-            results, vote_field="decision", weighted=True, confidence_field="confidence"
-        )
+        voted = ar.strategy_vote(results, vote_field="decision", weighted=True, confidence_field="confidence")
         # True has 0.9 weight vs False with 1.0 total
         assert voted["decision"] is False
 
@@ -175,19 +171,19 @@ class TestFindResultFiles:
         (tmp_path / "agent-1" / "result.json").write_text("{}")
         (tmp_path / "agent-2").mkdir()
         (tmp_path / "agent-2" / "result.json").write_text("{}")
-        
+
         files = ar.find_result_files(tmp_path)
         assert len(files) == 2
 
     def test_fallback_to_any_json(self, tmp_path):
         (tmp_path / "output.json").write_text("{}")
-        
+
         files = ar.find_result_files(tmp_path, pattern="result.json")
         assert len(files) == 1
 
     def test_fallback_to_markdown(self, tmp_path):
         (tmp_path / "report.md").write_text("# Report")
-        
+
         files = ar.find_result_files(tmp_path)
         assert len(files) == 1
 
@@ -198,21 +194,21 @@ class TestLoadFunctions:
     def test_load_json_file(self, tmp_path):
         f = tmp_path / "test.json"
         f.write_text('{"key": "value"}')
-        
+
         result = ar.load_json_file(f)
         assert result == {"key": "value"}
 
     def test_load_json_file_invalid(self, tmp_path):
         f = tmp_path / "bad.json"
         f.write_text("not json")
-        
+
         result = ar.load_json_file(f)
         assert result is None
 
     def test_load_text_file(self, tmp_path):
         f = tmp_path / "test.txt"
         f.write_text("hello world")
-        
+
         result = ar.load_text_file(f)
         assert result == "hello world"
 
@@ -224,9 +220,9 @@ class TestIntegration:
         files = ar.find_result_files(tmp_outputs)
         results = [ar.load_json_file(f) for f in files]
         results = [r for r in results if r is not None]
-        
+
         merged = ar.strategy_merge(results)
-        
+
         # All modules should be present
         assert "module" in merged or len(results) == 3
 
@@ -234,9 +230,9 @@ class TestIntegration:
         files = ar.find_result_files(tmp_outputs)
         results = [ar.load_json_file(f) for f in files]
         results = [r for r in results if r is not None]
-        
+
         voted = ar.strategy_vote(results, vote_field="decision")
-        
+
         # 2 True vs 1 False
         assert voted["decision"] is True
         assert voted["winner_count"] == 2
@@ -312,9 +308,18 @@ class TestIncrementalRollup:
 
     def _envelopes(self):
         return [
-            {"status": "ok", "metrics": {"tokens_used": 100, "cost_usd": 0.01, "duration_seconds": 1.0, "model": "claude-opus-4"}},
-            {"status": "ok", "metrics": {"tokens_used": 250, "cost_usd": 0.04, "duration_seconds": 2.5, "model": "gpt-4"}},
-            {"status": "ok", "metrics": {"tokens_used": 50, "cost_usd": 0.005, "duration_seconds": 0.5, "model": "claude-opus-4"}},
+            {
+                "status": "ok",
+                "metrics": {"tokens_used": 100, "cost_usd": 0.01, "duration_seconds": 1.0, "model": "claude-opus-4"},
+            },
+            {
+                "status": "ok",
+                "metrics": {"tokens_used": 250, "cost_usd": 0.04, "duration_seconds": 2.5, "model": "gpt-4"},
+            },
+            {
+                "status": "ok",
+                "metrics": {"tokens_used": 50, "cost_usd": 0.005, "duration_seconds": 0.5, "model": "claude-opus-4"},
+            },
         ]
 
     def test_incremental_equals_batch(self):
@@ -393,10 +398,14 @@ class TestStreamingMainIntegration:
         out = tmp_path / "report.json"
         argv = [
             "aggregate_results.py",
-            "--input-dir", str(root),
-            "--output", str(out),
-            "--strategy", "merge",
-            "--max-memory-mb", str(100 / (1024 * 1024)),  # 100-byte budget
+            "--input-dir",
+            str(root),
+            "--output",
+            str(out),
+            "--strategy",
+            "merge",
+            "--max-memory-mb",
+            str(100 / (1024 * 1024)),  # 100-byte budget
             "--include-stats",
         ]
         monkeypatch.setattr("sys.argv", argv)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,5 @@
 """Tests for scripts/_common.py."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -77,9 +78,9 @@ class TestCheckCircuitBreakerCounters:
             results = [_R("failed")] * failed + [_R("ok")] * (total - failed)
             list_out = _common.check_circuit_breaker(results, threshold, min_samples)
             counter_out = _common.check_circuit_breaker_counters(failed, total, threshold, min_samples)
-            assert list_out == counter_out, (
-                f"mismatch: list={list_out} counter={counter_out} for {(failed, total, threshold, min_samples)}"
-            )
+            assert (
+                list_out == counter_out
+            ), f"mismatch: list={list_out} counter={counter_out} for {(failed, total, threshold, min_samples)}"
 
 
 class TestValidateTasksFile:

--- a/tests/test_credential_helper.py
+++ b/tests/test_credential_helper.py
@@ -1,7 +1,7 @@
 """Tests for scripts/credential_helper.py."""
+
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 from unittest import mock
@@ -140,9 +140,7 @@ class TestOzSecretBackend:
         def fake_run(cmd, **kwargs):
             cmds.append(cmd)
             if cmd[2] == "create":
-                raise subprocess.CalledProcessError(
-                    1, cmd, stderr="Error: secret already exists"
-                )
+                raise subprocess.CalledProcessError(1, cmd, stderr="Error: secret already exists")
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
         monkeypatch.setattr(subprocess, "run", fake_run)

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -1,4 +1,5 @@
 """Tests for scripts/dependency_graph.py."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,5 @@
 """Tests for scripts/_log.py."""
+
 from __future__ import annotations
 
 import io
@@ -142,8 +143,6 @@ class TestBufferedFlush:
     """P1-D: flush policy. Buffered by default, atexit-safe, replay-complete."""
 
     def test_buffered_does_not_flush_every_event(self):
-        buf = io.StringIO()
-
         class CountingBuffer(io.StringIO):
             def __init__(self):
                 super().__init__()

--- a/tests/test_oz_metrics.py
+++ b/tests/test_oz_metrics.py
@@ -6,10 +6,10 @@ Covers:
 - `to_envelope` includes metrics in result-schema envelope
 - `_rollup_metrics` sums totals and builds per-model breakdown
 """
+
 from __future__ import annotations
 
-from scripts import spawn_oz
-from scripts import aggregate_results
+from scripts import aggregate_results, spawn_oz
 
 
 class TestExtractMetricsFromOz:
@@ -54,9 +54,7 @@ class TestExtractMetricsFromOz:
 
 class TestWaitForRunPopulatesMetrics:
     def test_populates_fields_on_success(self, monkeypatch):
-        r = spawn_oz.OzAgentResult(
-            task_id="t1", task="x", run_id="abc", status="running", start_time=1.0
-        )
+        r = spawn_oz.OzAgentResult(task_id="t1", task="x", run_id="abc", status="running", start_time=1.0)
 
         def fake_poll(run_id):
             return {
@@ -93,9 +91,7 @@ class TestEnvelopeIncludesMetrics:
         assert env["metrics"]["duration_seconds"] == 2.0
 
     def test_envelope_omits_metrics_when_empty(self):
-        r = spawn_oz.OzAgentResult(
-            task_id="t1", task="x", run_id="abc", status="running"
-        )
+        r = spawn_oz.OzAgentResult(task_id="t1", task="x", run_id="abc", status="running")
         env = r.to_envelope()
         assert "metrics" not in env
 

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -4,7 +4,6 @@ import json
 from pathlib import Path
 
 import pytest
-
 import run_evals as re_mod
 
 

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -1,4 +1,5 @@
 """Tests for scripts/schema_validator.py + --validate-schema integration."""
+
 from __future__ import annotations
 
 import json
@@ -6,10 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
 from scripts import schema_validator as sv
-
 
 VALID = {
     "schema_version": "1",
@@ -45,9 +43,7 @@ class TestBuiltinValidator:
         assert any("JSON object" in e for e in errs)
 
     def test_bad_metrics_type(self):
-        errs = sv._builtin_validate(
-            {"schema_version": "1", "status": "ok", "metrics": "not-a-dict"}
-        )
+        errs = sv._builtin_validate({"schema_version": "1", "status": "ok", "metrics": "not-a-dict"})
         assert any("metrics must be an object" in e for e in errs)
 
     def test_extra_fields_allowed(self):
@@ -128,10 +124,15 @@ class TestAggregateValidateSchemaIntegration:
 
         proc = subprocess.run(
             [
-                sys.executable, "-m", "scripts.aggregate_results",
-                "--input-dir", str(out),
-                "--output", str(report),
-                "--strategy", "merge",
+                sys.executable,
+                "-m",
+                "scripts.aggregate_results",
+                "--input-dir",
+                str(out),
+                "--output",
+                str(report),
+                "--strategy",
+                "merge",
                 "--validate-schema",
                 "--include-stats",
             ],
@@ -152,10 +153,15 @@ class TestAggregateValidateSchemaIntegration:
 
         proc = subprocess.run(
             [
-                sys.executable, "-m", "scripts.aggregate_results",
-                "--input-dir", str(out),
-                "--output", str(report),
-                "--strategy", "merge",
+                sys.executable,
+                "-m",
+                "scripts.aggregate_results",
+                "--input-dir",
+                str(out),
+                "--output",
+                str(report),
+                "--strategy",
+                "merge",
                 "--validate-schema",
             ],
             capture_output=True,

--- a/tests/test_spawn_docker.py
+++ b/tests/test_spawn_docker.py
@@ -1,7 +1,6 @@
 """Tests for spawn_docker.py."""
 
 import subprocess
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -84,7 +83,7 @@ class TestBackoffCalculation:
         b0 = sd.calculate_backoff(0, base_delay=2.0, max_delay=60.0)
         b1 = sd.calculate_backoff(1, base_delay=2.0, max_delay=60.0)
         b2 = sd.calculate_backoff(2, base_delay=2.0, max_delay=60.0)
-        
+
         # Should grow exponentially (with jitter)
         assert b0 < b1 < b2
 
@@ -135,7 +134,7 @@ class TestSpawnContainer:
             stderr="",
             returncode=0,
         )
-        
+
         result = sd.spawn_container(
             task="Test task",
             task_id="agent-0-test",
@@ -149,17 +148,15 @@ class TestSpawnContainer:
             share="team",
             extra_env={},
         )
-        
+
         assert result.status == "running"
         assert result.container_id == "container123"
         assert mock_run.called
 
     @patch("spawn_docker.subprocess.run")
     def test_failed_spawn(self, mock_run, tmp_path):
-        mock_run.side_effect = subprocess.CalledProcessError(
-            1, "docker", stderr="Image not found"
-        )
-        
+        mock_run.side_effect = subprocess.CalledProcessError(1, "docker", stderr="Image not found")
+
         result = sd.spawn_container(
             task="Test task",
             task_id="agent-0-test",
@@ -173,7 +170,7 @@ class TestSpawnContainer:
             share="team",
             extra_env={},
         )
-        
+
         assert result.status == "failed"
         assert result.container_id == ""
 
@@ -184,18 +181,18 @@ class TestWaitForContainer:
     @patch("spawn_docker.subprocess.run")
     def test_successful_completion(self, mock_run):
         mock_run.return_value = MagicMock(stdout="0\n", stderr="")
-        
+
         exit_code, error = sd.wait_for_container("test-container", timeout=60)
-        
+
         assert exit_code == 0
         assert error == ""
 
     @patch("spawn_docker.subprocess.run")
     def test_failed_container(self, mock_run):
         mock_run.return_value = MagicMock(stdout="1\n", stderr="")
-        
+
         exit_code, error = sd.wait_for_container("test-container", timeout=60)
-        
+
         assert exit_code == 1
 
     @patch("spawn_docker.subprocess.run")
@@ -205,9 +202,9 @@ class TestWaitForContainer:
             subprocess.TimeoutExpired("docker wait", 60),
             MagicMock(stdout="", stderr=""),
         ]
-        
+
         exit_code, error = sd.wait_for_container("test-container", timeout=60)
-        
+
         assert exit_code == -1
         assert "Timeout" in error
 
@@ -218,9 +215,9 @@ class TestValidateTasksFile:
     def test_valid_file(self, tmp_path):
         tasks_file = tmp_path / "tasks.txt"
         tasks_file.write_text("Task 1\nTask 2\n# Comment\nTask 3")
-        
+
         result = sd.validate_tasks_file(tasks_file)
-        
+
         assert result == ["Task 1", "Task 2", "Task 3"]
 
     def test_missing_file(self, tmp_path):
@@ -230,6 +227,6 @@ class TestValidateTasksFile:
     def test_empty_file(self, tmp_path):
         tasks_file = tmp_path / "empty.txt"
         tasks_file.write_text("# Only comments\n\n")
-        
+
         with pytest.raises(SystemExit):
             sd.validate_tasks_file(tasks_file)

--- a/tests/test_spawn_k8s.py
+++ b/tests/test_spawn_k8s.py
@@ -3,8 +3,6 @@
 import subprocess
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 import spawn_k8s as sk
 
 
@@ -44,19 +42,19 @@ class TestCreateJobManifest:
     """Tests for create_job_manifest function."""
 
     def _kwargs(self, **overrides):
-        base = dict(
-            task="Analyze X",
-            job_name="agent-0-analyze-x",
-            namespace="warp-agents",
-            image="warpdotdev/dev-base:latest",
-            secret_name="warp-api-key",
-            pvc_name=None,
-            memory_request="2Gi",
-            memory_limit="4Gi",
-            cpu_request="1",
-            cpu_limit="2",
-            share="team",
-        )
+        base = {
+            "task": "Analyze X",
+            "job_name": "agent-0-analyze-x",
+            "namespace": "warp-agents",
+            "image": "warpdotdev/dev-base:latest",
+            "secret_name": "warp-api-key",
+            "pvc_name": None,
+            "memory_request": "2Gi",
+            "memory_limit": "4Gi",
+            "cpu_request": "1",
+            "cpu_limit": "2",
+            "share": "team",
+        }
         base.update(overrides)
         return base
 

--- a/tests/test_spawn_oz.py
+++ b/tests/test_spawn_oz.py
@@ -1,9 +1,8 @@
 """Tests for scripts/spawn_oz.py."""
+
 from __future__ import annotations
 
-import json
 import subprocess
-from unittest import mock
 
 import pytest
 
@@ -129,9 +128,7 @@ class TestPollRun:
 
 class TestWaitForRun:
     def test_terminal_state_captured(self, monkeypatch):
-        r = spawn_oz.OzAgentResult(
-            task_id="t1", task="x", run_id="abc", status="running", start_time=1.0
-        )
+        r = spawn_oz.OzAgentResult(task_id="t1", task="x", run_id="abc", status="running", start_time=1.0)
 
         def fake_poll(run_id):
             return {
@@ -148,9 +145,7 @@ class TestWaitForRun:
         assert result.end_time is not None
 
     def test_non_terminal_times_out(self, monkeypatch):
-        r = spawn_oz.OzAgentResult(
-            task_id="t1", task="x", run_id="abc", status="running", start_time=1.0
-        )
+        r = spawn_oz.OzAgentResult(task_id="t1", task="x", run_id="abc", status="running", start_time=1.0)
 
         def fake_poll(run_id):
             return {"status": "running"}
@@ -166,9 +161,14 @@ class TestWaitForRun:
 class TestToEnvelope:
     def test_succeeded_maps_to_ok(self):
         r = spawn_oz.OzAgentResult(
-            task_id="t1", task="x", run_id="abc",
-            status="succeeded", start_time=1.0, end_time=3.5,
-            output="done", pr_url="https://github.com/a/b/pull/1",
+            task_id="t1",
+            task="x",
+            run_id="abc",
+            status="succeeded",
+            start_time=1.0,
+            end_time=3.5,
+            output="done",
+            pr_url="https://github.com/a/b/pull/1",
         )
         env = r.to_envelope()
         assert env["schema_version"] == "1"
@@ -180,7 +180,11 @@ class TestToEnvelope:
 
     def test_failed_maps_to_failed(self):
         r = spawn_oz.OzAgentResult(
-            task_id="t1", task="x", run_id="", status="failed", error="boom",
+            task_id="t1",
+            task="x",
+            run_id="",
+            status="failed",
+            error="boom",
         )
         env = r.to_envelope()
         assert env["status"] == "failed"

--- a/tests/test_wait_for_phase.py
+++ b/tests/test_wait_for_phase.py
@@ -1,10 +1,7 @@
 """Tests for wait_for_phase.py."""
 
 import json
-from datetime import datetime
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 import wait_for_phase as wfp
 
@@ -42,25 +39,25 @@ class TestGetDockerAgents:
             stdout="agent-1-task\nagent-1-other\n",
             returncode=0,
         )
-        
+
         agents = wfp.get_docker_agents("1")
-        
+
         assert agents == ["agent-1-task", "agent-1-other"]
 
     @patch("wait_for_phase.subprocess.run")
     def test_handles_empty_result(self, mock_run):
         mock_run.return_value = MagicMock(stdout="", returncode=0)
-        
+
         agents = wfp.get_docker_agents("nonexistent")
-        
+
         assert agents == []
 
     @patch("wait_for_phase.subprocess.run")
     def test_handles_exception(self, mock_run):
         mock_run.side_effect = Exception("Docker not running")
-        
+
         agents = wfp.get_docker_agents("1")
-        
+
         assert agents == []
 
 
@@ -73,9 +70,9 @@ class TestGetDockerStatus:
             stdout="running,0,2024-01-01T10:00:00Z,0001-01-01T00:00:00Z",
             returncode=0,
         )
-        
+
         status = wfp.get_docker_status("test-container")
-        
+
         assert status.status == wfp.Status.RUNNING
         assert status.exit_code is None
 
@@ -85,9 +82,9 @@ class TestGetDockerStatus:
             stdout="exited,0,2024-01-01T10:00:00Z,2024-01-01T10:05:00Z",
             returncode=0,
         )
-        
+
         status = wfp.get_docker_status("test-container")
-        
+
         assert status.status == wfp.Status.COMPLETED
         assert status.exit_code == 0
 
@@ -97,9 +94,9 @@ class TestGetDockerStatus:
             stdout="exited,1,2024-01-01T10:00:00Z,2024-01-01T10:05:00Z",
             returncode=0,
         )
-        
+
         status = wfp.get_docker_status("test-container")
-        
+
         assert status.status == wfp.Status.FAILED
         assert status.exit_code == 1
 
@@ -109,9 +106,9 @@ class TestGetDockerStatus:
             stdout="created,0,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z",
             returncode=0,
         )
-        
+
         status = wfp.get_docker_status("test-container")
-        
+
         assert status.status == wfp.Status.PENDING
 
 
@@ -124,9 +121,9 @@ class TestGetK8sJobs:
             stdout="job-phase-1-a job-phase-1-b",
             returncode=0,
         )
-        
+
         jobs = wfp.get_k8s_jobs("1", "warp-agents")
-        
+
         assert len(jobs) == 2
 
     @patch("wait_for_phase.subprocess.run")
@@ -136,9 +133,9 @@ class TestGetK8sJobs:
             Exception("Label not found"),
             MagicMock(stdout="agent-1-task other-job phase-1-work", returncode=0),
         ]
-        
+
         jobs = wfp.get_k8s_jobs("1", "warp-agents")
-        
+
         # Should match jobs containing "-1-" or "phase-1"
         assert "phase-1-work" in jobs
 
@@ -149,48 +146,46 @@ class TestGetK8sStatus:
     @patch("wait_for_phase.subprocess.run")
     def test_succeeded_job(self, mock_run):
         mock_run.return_value = MagicMock(
-            stdout=json.dumps({
-                "status": {
-                    "succeeded": 1,
-                    "active": 0,
-                    "failed": 0,
-                    "startTime": "2024-01-01T10:00:00Z",
-                    "completionTime": "2024-01-01T10:05:00Z",
+            stdout=json.dumps(
+                {
+                    "status": {
+                        "succeeded": 1,
+                        "active": 0,
+                        "failed": 0,
+                        "startTime": "2024-01-01T10:00:00Z",
+                        "completionTime": "2024-01-01T10:05:00Z",
+                    }
                 }
-            }),
+            ),
             returncode=0,
         )
-        
+
         status = wfp.get_k8s_status("test-job", "default")
-        
+
         assert status.status == wfp.Status.COMPLETED
         assert status.exit_code == 0
 
     @patch("wait_for_phase.subprocess.run")
     def test_failed_job(self, mock_run):
         mock_run.return_value = MagicMock(
-            stdout=json.dumps({
-                "status": {"succeeded": 0, "active": 0, "failed": 1}
-            }),
+            stdout=json.dumps({"status": {"succeeded": 0, "active": 0, "failed": 1}}),
             returncode=0,
         )
-        
+
         status = wfp.get_k8s_status("test-job", "default")
-        
+
         assert status.status == wfp.Status.FAILED
         assert status.exit_code == 1
 
     @patch("wait_for_phase.subprocess.run")
     def test_running_job(self, mock_run):
         mock_run.return_value = MagicMock(
-            stdout=json.dumps({
-                "status": {"succeeded": 0, "active": 1, "failed": 0}
-            }),
+            stdout=json.dumps({"status": {"succeeded": 0, "active": 1, "failed": 0}}),
             returncode=0,
         )
-        
+
         status = wfp.get_k8s_status("test-job", "default")
-        
+
         assert status.status == wfp.Status.RUNNING
 
 
@@ -200,7 +195,7 @@ class TestWaitForAgents:
     def test_all_complete_immediately(self):
         def mock_status(agent):
             return wfp.AgentStatus(agent, wfp.Status.COMPLETED, exit_code=0)
-        
+
         statuses, success = wfp.wait_for_agents(
             agents=["a1", "a2"],
             get_status_fn=mock_status,
@@ -208,20 +203,20 @@ class TestWaitForAgents:
             poll_interval=1,
             fail_fast=False,
         )
-        
+
         assert success is True
         assert len(statuses) == 2
         assert all(s.status == wfp.Status.COMPLETED for s in statuses)
 
     def test_fail_fast_on_failure(self):
         call_count = [0]
-        
+
         def mock_status(agent):
             call_count[0] += 1
             if agent == "a1":
                 return wfp.AgentStatus(agent, wfp.Status.FAILED, exit_code=1)
             return wfp.AgentStatus(agent, wfp.Status.RUNNING)
-        
+
         statuses, success = wfp.wait_for_agents(
             agents=["a1", "a2"],
             get_status_fn=mock_status,
@@ -229,7 +224,7 @@ class TestWaitForAgents:
             poll_interval=0.1,
             fail_fast=True,
         )
-        
+
         assert success is False
         # Should have checked status of failed agent
 
@@ -239,7 +234,7 @@ class TestWaitForAgents:
             "a2": wfp.AgentStatus("a2", wfp.Status.FAILED, exit_code=1),
             "a3": wfp.AgentStatus("a3", wfp.Status.COMPLETED, exit_code=0),
         }
-        
+
         statuses, success = wfp.wait_for_agents(
             agents=["a1", "a2", "a3"],
             get_status_fn=lambda a: statuses_map[a],
@@ -247,7 +242,7 @@ class TestWaitForAgents:
             poll_interval=1,
             fail_fast=False,
         )
-        
+
         assert success is True  # All agents reached terminal state
         completed = sum(1 for s in statuses if s.status == wfp.Status.COMPLETED)
         assert completed == 2


### PR DESCRIPTION
## Summary
Phase 7 P1-A delivers the streaming aggregation path in `scripts/aggregate_results.py`. The pre-change pipeline did `list(executor.map(load_file, files))` \u2014 i.e. materialized every envelope in RAM before running the strategy. At 10k+ envelopes this is a straight path to OOM. This PR rewrites the loader around `iter_loaded_files` (a bounded-window producer/consumer over `ThreadPoolExecutor`) and folds merge/concat strategies directly over the stream.

## Changes
- `iter_loaded_files(files, max_workers=8)` \u2014 lazy `(path, data)` generator; in-flight window = `max_workers * 4`; sequential fast-path for <=10 files or `max_workers <= 1`.
- `merge_dicts` / `strategy_merge` / `strategy_concat` / `_rollup_metrics` now accept any `Iterable`. Existing list callers are unaffected (semantically identical; `policy='first'` switched from reverse-update to per-key skip, which is equivalent on lists and works on generators).
- `_IncrementalRollup` \u2014 inline metrics accumulator that runs during the load. `_rollup_metrics(list)` delegates to it so both paths share one code path.
- `--max-memory-mb MB` \u2014 per-envelope data-budget spillover. Payloads whose `data` serializes above the budget are replaced with `{artifact_path, artifact_size}` pointers per `references/result-schema.md` \"Non-envelope outputs\". The envelope is never mutated; the pointer lives on a shallow copy. Spill count surfaces as `stats.spilled_payloads` and an `aggregate.spill` structured-log event.
- `--load-workers N` \u2014 loader parallelism knob (default 8).
- `vote`/`latest` still materialize (two-pass) but consume the same streaming loader so stats/provenance/rollup accounting is single-pass across all strategies.

## Benchmarks
Disk-backed merge (macOS arm64, Python 3.14.4; `bench/test_streaming_aggregation.py`):

**Wall-clock** \u2014 parity, not a throughput win.
| Pipeline                | N     | Mean    |
|-------------------------|-------|---------|
| `_materialized_merge`   | 1000  | 65.7 ms |
| `_materialized_merge`   | 10000 | 631 ms  |
| `_streaming_merge`      | 1000  | 63.8 ms |
| `_streaming_merge`      | 10000 | 662 ms  |

**Peak memory** (tracemalloc) \u2014 this is the real win.
| N      | Materialized | Streaming | Ratio  |
|--------|--------------|-----------|--------|
| 1,000  | 3,299 KiB    | 1,158 KiB | 2.85x  |
| 5,000  | 11,506 KiB   | 1,160 KiB | 9.92x  |
| 10,000 | 21,813 KiB   | 1,164 KiB | 18.73x |

Streaming peak is **constant** (~1.16 MiB). Materialized peak is O(N). At 10k envelopes we hold 18.7x less; the ratio keeps improving as the corpus scales.

## Honest gate assessment
- Plan gate: \"\u22655x throughput on 10k\". **Not met.** JSON parse dominates both paths; the bounded-window queue adds modest overhead vs `executor.map`'s internal batching. Any future throughput win requires async I/O or skipping JSON re-parse entirely.
- Implicit memory gate (\"memory RSS capped at a configurable ceiling\"): **met.** Flat ~1.16 MiB peak; `--max-memory-mb` gives operators explicit per-envelope control for outlier payloads.
- Recommendation: accept the refactor for the memory profile; defer throughput improvement to a P2 if demand surfaces.

## Tests
- 244 passing (+17 new).
- New classes in `tests/test_aggregate_results.py`: `TestIterLoadedFiles` (5), `TestMergeDictsStreaming` (3), `TestIncrementalRollup` (3), `TestMaybeSpillData` (4), `TestStreamingMainIntegration` (1 end-to-end that runs `main()` with `--max-memory-mb` and asserts `stats.spilled_payloads == 2`).

## Risk
Low. The public CLI surface is additive (`--max-memory-mb`, `--load-workers` are new and default to no behaviour change). Existing tests all pass unchanged. `merge_dicts(..., policy='first')` changed implementation strategy but the pytest suite covers both list and generator inputs for parity.

---

- Run: https://app.warp.dev/conversation/eafbfe6f-cef2-4e02-84be-720ef9f77c1f
- Plan: https://app.warp.dev/drive/notebook/HGWnZaIyaPPnSKlDFSlbWU

Co-Authored-By: Oz <oz-agent@warp.dev>